### PR TITLE
Improve form placeholders

### DIFF
--- a/src/components/Input.js
+++ b/src/components/Input.js
@@ -1,12 +1,13 @@
 import React from "react";
 import { View, Text, TextInput } from "react-native";
 
-export default function Input({ label, style, ...props }) {
+export default function Input({ label, style, placeholderTextColor = "#94A3B8", ...props }) {
   return (
     <View style={{ marginBottom: 12 }}>
       <Text style={{ marginBottom: 6, color: "#475569" }}>{label}</Text>
       <TextInput
         {...props}
+        placeholderTextColor={placeholderTextColor}
         style={{
           backgroundColor: "#fff",
           borderWidth: 1,

--- a/src/screens/Items/index.js
+++ b/src/screens/Items/index.js
@@ -332,20 +332,21 @@ export function AddItemScreen({ route, navigation }) {
     <SafeAreaView style={{ flex: 1, backgroundColor: "#F8FAFC" }}>
       <FormScrollContainer contentContainerStyle={{ paddingBottom: 24 }}>
         <Text style={{ fontSize: 18, fontWeight: "700", marginBottom: 12 }}>{isEdit ? "Edit Barang" : "Tambah Barang"}</Text>
-        <Input label="Nama" value={name} onChangeText={setName} />
-        <Input label="Kategori" value={category} onChangeText={setCategory} />
+        <Input label="Nama" value={name} onChangeText={setName} placeholder="contoh: Kardus 40x40" />
+        <Input label="Kategori" value={category} onChangeText={setCategory} placeholder="contoh: Kemasan" />
         <Input
           label="Harga (Rp)"
           value={price}
           onChangeText={text => setPrice(formatNumberInput(text))}
           keyboardType="numeric"
-          placeholder="0"
+          placeholder="contoh: 125000"
         />
         <Input
           label="Stok"
           value={stock}
           onChangeText={text => setStock(formatNumberInput(text))}
           keyboardType="numeric"
+          placeholder="contoh: 100"
         />
         <TouchableOpacity
           onPress={save}
@@ -389,8 +390,8 @@ export function StockMoveScreen({ route, navigation }) {
         <Text style={{ color: "#64748B" }}>
           {item.name} • Stok: {formatNumberValue(item.stock)}
         </Text>
-        <Input label="Qty" value={qty} onChangeText={setQty} keyboardType="numeric" />
-        <Input label="Catatan (opsional)" value={note} onChangeText={setNote} />
+        <Input label="Qty" value={qty} onChangeText={setQty} keyboardType="numeric" placeholder="contoh: 5" />
+        <Input label="Catatan (opsional)" value={note} onChangeText={setNote} placeholder="contoh: Rak gudang A" />
         <TouchableOpacity
           onPress={commit}
           style={{

--- a/src/screens/purchaseOrders/index.js
+++ b/src/screens/purchaseOrders/index.js
@@ -285,14 +285,14 @@ export function AddPurchaseOrderScreen({ route, navigation }) {
           value={quantity}
           onChangeText={text => setQuantity(formatNumberInput(text))}
           keyboardType="numeric"
-          placeholder="0"
+          placeholder="contoh: 50"
         />
         <Input
           label="Harga Satuan"
           value={price}
           onChangeText={text => setPrice(formatNumberInput(text))}
           keyboardType="numeric"
-          placeholder="0"
+          placeholder="contoh: 125000"
         />
         <DatePickerField label="Tanggal PO" value={orderDate} onChange={setOrderDate} />
         <View style={{ marginBottom: 12 }}>
@@ -440,14 +440,14 @@ export function EditPurchaseOrderScreen({ route, navigation }) {
           value={quantity}
           onChangeText={text => setQuantity(formatNumberInput(text))}
           keyboardType="numeric"
-          placeholder="0"
+          placeholder="contoh: 50"
         />
         <Input
           label="Harga Satuan"
           value={price}
           onChangeText={text => setPrice(formatNumberInput(text))}
           keyboardType="numeric"
-          placeholder="0"
+          placeholder="contoh: 125000"
         />
         <DatePickerField label="Tanggal PO" value={orderDate} onChange={setOrderDate} />
         <View style={{ marginBottom: 12 }}>


### PR DESCRIPTION
## Summary
- add a default placeholder text color to the shared Input component so helper text stays visible
- provide example placeholder text across item forms, including stock movements
- refresh purchase order quantity and price placeholders with descriptive examples

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d332fa32408325b3703a184e2e7e85