### PR TITLE
feat: improve PO item table and dashboard navigation

### DIFF
--- a/src/screens/DashboardScreen.js
+++ b/src/screens/DashboardScreen.js
@@ -93,13 +93,18 @@ export default function DashboardScreen({ navigation }) {
         `,
         params: [search, `%${search}%`, `%${search}%`, limit + 1, offset],
       }),
-      mapRow: row => ({
-        key: String(row.id),
-        title: row.name,
-        subtitle: `${row.category && row.category.trim() ? row.category : "Tanpa kategori"} • ${formatNumberValue(row.stock)} stok`,
-        trailingPrimary: formatCurrencyValue(row.totalValue),
-        trailingSecondary: `@ ${formatCurrencyValue(row.price)}`,
-      }),
+      mapRow: row => {
+        const itemId = Number(row.id);
+        return {
+          key: String(row.id),
+          title: row.name,
+          subtitle: `${row.category && row.category.trim() ? row.category : "Tanpa kategori"} • ${formatNumberValue(row.stock)} stok`,
+          trailingPrimary: formatCurrencyValue(row.totalValue),
+          trailingSecondary: `@ ${formatCurrencyValue(row.price)}`,
+          entityType: Number.isFinite(itemId) ? "item" : undefined,
+          entityId: Number.isFinite(itemId) ? itemId : null,
+        };
+      },
     },
     poFull: {
       title: "Semua Purchase Order",
@@ -138,6 +143,7 @@ export default function DashboardScreen({ navigation }) {
         params: [search, `%${search}%`, `%${search}%`, `%${search}%`, `%${search}%`, limit + 1, offset],
       }),
       mapRow: row => {
+        const orderId = Number(row.id);
         const totalQuantity = Number(row.total_quantity ?? 0);
         const totalValue = Number(row.total_value ?? 0);
         const itemCount = Number(row.item_count ?? 0);
@@ -151,6 +157,8 @@ export default function DashboardScreen({ navigation }) {
           subtitle: `${orderer} • ${formatDateDisplay(row.order_date)} • ${statusLabel}`,
           trailingPrimary: formatCurrencyValue(totalValue),
           trailingSecondary: `${formatNumberValue(itemCount || (totalQuantity > 0 ? 1 : 0))} barang • ${formatNumberValue(totalQuantity)} pcs`,
+          entityType: Number.isFinite(orderId) ? "po" : undefined,
+          entityId: Number.isFinite(orderId) ? orderId : null,
         };
       },
     },
@@ -192,6 +200,7 @@ export default function DashboardScreen({ navigation }) {
         params: [search, `%${search}%`, `%${search}%`, `%${search}%`, `%${search}%`, limit + 1, offset],
       }),
       mapRow: row => {
+        const orderId = Number(row.id);
         const totalQuantity = Number(row.total_quantity ?? 0);
         const totalValue = Number(row.total_value ?? 0);
         const itemCount = Number(row.item_count ?? 0);
@@ -205,6 +214,8 @@ export default function DashboardScreen({ navigation }) {
           subtitle: `${orderer} • ${formatDateDisplay(row.order_date)} • ${statusLabel}`,
           trailingPrimary: formatCurrencyValue(totalValue),
           trailingSecondary: `${formatNumberValue(itemCount || (totalQuantity > 0 ? 1 : 0))} barang • ${formatNumberValue(totalQuantity)} pcs`,
+          entityType: Number.isFinite(orderId) ? "po" : undefined,
+          entityId: Number.isFinite(orderId) ? orderId : null,
         };
       },
     },
@@ -245,6 +256,7 @@ export default function DashboardScreen({ navigation }) {
         params: [search, `%${search}%`, `%${search}%`, `%${search}%`, `%${search}%`, limit + 1, offset],
       }),
       mapRow: row => {
+        const orderId = Number(row.id);
         const totalQuantity = Number(row.total_quantity ?? 0);
         const totalValue = Number(row.total_value ?? 0);
         const itemCount = Number(row.item_count ?? 0);
@@ -258,6 +270,8 @@ export default function DashboardScreen({ navigation }) {
           subtitle: `${orderer} • ${formatDateDisplay(row.order_date)} • ${statusLabel}`,
           trailingPrimary: formatCurrencyValue(totalValue),
           trailingSecondary: `${formatNumberValue(itemCount || (totalQuantity > 0 ? 1 : 0))} barang • ${formatNumberValue(totalQuantity)} pcs`,
+          entityType: Number.isFinite(orderId) ? "po" : undefined,
+          entityId: Number.isFinite(orderId) ? orderId : null,
         };
       },
     },
@@ -520,6 +534,49 @@ export default function DashboardScreen({ navigation }) {
     loadDetailPaginated({ type: detailModal.type, searchTerm: term, reset: true });
   }
 
+  async function handleDetailRowPress(row) {
+    if (!row || !row.entityType) return;
+    if (row.entityType === "item") {
+      const itemId = Number(row.entityId);
+      if (!Number.isFinite(itemId)) return;
+      try {
+        const res = await exec(
+          `SELECT id, name, category, price, stock FROM items WHERE id = ?`,
+          [itemId],
+        );
+        if (!res.rows.length) {
+          Alert.alert("Data Tidak Ditemukan", "Barang mungkin telah dihapus.");
+          return;
+        }
+        const itemRow = res.rows.item(0);
+        closeDetail();
+        navigation.navigate("AddItem", {
+          item: {
+            id: itemRow.id,
+            name: itemRow.name,
+            category: itemRow.category,
+            price: Number(itemRow.price ?? 0),
+            stock: Number(itemRow.stock ?? 0),
+          },
+          onDone: () => {
+            load();
+          },
+        });
+      } catch (error) {
+        console.log("ITEM DETAIL OPEN ERROR:", error);
+        Alert.alert("Gagal", "Tidak dapat membuka detail barang.");
+      }
+    } else if (row.entityType === "po") {
+      const orderId = Number(row.entityId);
+      if (!Number.isFinite(orderId)) return;
+      closeDetail();
+      navigation.navigate("PurchaseOrderDetail", {
+        orderId,
+        onDone: load,
+      });
+    }
+  }
+
   async function openDetail(statKey) {
     const paginatedMap = {
       categoriesFull: "categoriesFull",
@@ -569,11 +626,14 @@ export default function DashboardScreen({ navigation }) {
         const rows = [];
         for (let i = 0; i < res.rows.length; i++) {
           const row = res.rows.item(i);
+          const itemId = Number(row.id);
           rows.push({
             key: String(row.id),
             title: row.name,
             subtitle: `${row.category || "Tanpa kategori"} • ${formatNumber(row.stock)} stok`,
             trailingPrimary: `@ ${formatCurrency(row.price)}`,
+            entityType: Number.isFinite(itemId) ? "item" : undefined,
+            entityId: Number.isFinite(itemId) ? itemId : null,
           });
         }
         modalState = {
@@ -593,12 +653,15 @@ export default function DashboardScreen({ navigation }) {
         const rows = [];
         for (let i = 0; i < res.rows.length; i++) {
           const row = res.rows.item(i);
+          const itemId = Number(row.id);
           rows.push({
             key: String(row.id),
             title: row.name,
             subtitle: row.category || "Tanpa kategori",
             trailingPrimary: `${formatNumber(row.stock)} stok`,
             trailingSecondary: `@ ${formatCurrency(row.price)}`,
+            entityType: Number.isFinite(itemId) ? "item" : undefined,
+            entityId: Number.isFinite(itemId) ? itemId : null,
           });
         }
         modalState = {
@@ -618,12 +681,15 @@ export default function DashboardScreen({ navigation }) {
         const rows = [];
         for (let i = 0; i < res.rows.length; i++) {
           const row = res.rows.item(i);
+          const itemId = Number(row.id);
           rows.push({
             key: String(row.id),
             title: row.name,
             subtitle: `${row.category || "Tanpa kategori"} • ${formatNumber(row.stock)} stok`,
             trailingPrimary: formatCurrency(row.totalValue),
             trailingSecondary: `@ ${formatCurrency(row.price)}`,
+            entityType: Number.isFinite(itemId) ? "item" : undefined,
+            entityId: Number.isFinite(itemId) ? itemId : null,
           });
         }
         modalState = {
@@ -635,7 +701,7 @@ export default function DashboardScreen({ navigation }) {
         };
       } else if (statKey === "outQty" || statKey === "outValue") {
         const res = await exec(`
-          SELECT h.id, i.name, i.category, h.qty, h.created_at, i.price, (h.qty * i.price) as totalValue
+          SELECT h.id, i.id as item_id, i.name, i.category, h.qty, h.created_at, i.price, (h.qty * i.price) as totalValue
           FROM stock_history h JOIN items i ON i.id = h.item_id
           WHERE h.type = 'OUT'
           ORDER BY h.created_at DESC, h.id DESC
@@ -644,12 +710,15 @@ export default function DashboardScreen({ navigation }) {
         const rows = [];
         for (let i = 0; i < res.rows.length; i++) {
           const row = res.rows.item(i);
+          const itemId = Number(row.item_id);
           rows.push({
             key: String(row.id),
             title: row.name,
             subtitle: `${row.category || "Tanpa kategori"} • ${row.created_at}`,
             trailingPrimary: `${formatNumber(row.qty)} pcs`,
             trailingSecondary: formatCurrency(row.totalValue),
+            entityType: Number.isFinite(itemId) ? "item" : undefined,
+            entityId: Number.isFinite(itemId) ? itemId : null,
           });
         }
         modalState = {
@@ -1108,32 +1177,38 @@ export default function DashboardScreen({ navigation }) {
                     <FlatList
                       data={detailModal.rows}
                       keyExtractor={(item, index) => (item.key ? String(item.key) : `${detailModal.type || "row"}-${index}`)}
-                      renderItem={({ item, index }) => (
-                        <View
-                          style={{
-                            flexDirection: "row",
-                            alignItems: "flex-start",
-                            paddingVertical: 12,
-                            borderTopWidth: index === 0 ? 0 : 1,
-                            borderColor: "#E2E8F0",
-                          }}
-                        >
-                          <View style={{ flex: 1, paddingRight: 12 }}>
-                            <Text style={{ color: "#0F172A", fontWeight: "600" }}>{item.title}</Text>
-                            {item.subtitle ? (
-                              <Text style={{ color: "#64748B", fontSize: 12, marginTop: 4 }}>{item.subtitle}</Text>
-                            ) : null}
-                          </View>
-                          <View style={{ alignItems: "flex-end" }}>
-                            {item.trailingPrimary ? (
-                              <Text style={{ color: "#0F172A", fontWeight: "700" }}>{item.trailingPrimary}</Text>
-                            ) : null}
-                            {item.trailingSecondary ? (
-                              <Text style={{ color: "#94A3B8", fontSize: 12, marginTop: 4 }}>{item.trailingSecondary}</Text>
-                            ) : null}
-                          </View>
-                        </View>
-                      )}
+                      renderItem={({ item, index }) => {
+                        const isPressable = item?.entityType === "item" || item?.entityType === "po";
+                        return (
+                          <TouchableOpacity
+                            onPress={isPressable ? () => handleDetailRowPress(item) : undefined}
+                            disabled={!isPressable}
+                            activeOpacity={isPressable ? 0.7 : 1}
+                            style={{
+                              flexDirection: "row",
+                              alignItems: "flex-start",
+                              paddingVertical: 12,
+                              borderTopWidth: index === 0 ? 0 : 1,
+                              borderColor: "#E2E8F0",
+                            }}
+                          >
+                            <View style={{ flex: 1, paddingRight: 12 }}>
+                              <Text style={{ color: "#0F172A", fontWeight: "600" }}>{item.title}</Text>
+                              {item.subtitle ? (
+                                <Text style={{ color: "#64748B", fontSize: 12, marginTop: 4 }}>{item.subtitle}</Text>
+                              ) : null}
+                            </View>
+                            <View style={{ alignItems: "flex-end" }}>
+                              {item.trailingPrimary ? (
+                                <Text style={{ color: "#0F172A", fontWeight: "700" }}>{item.trailingPrimary}</Text>
+                              ) : null}
+                              {item.trailingSecondary ? (
+                                <Text style={{ color: "#94A3B8", fontSize: 12, marginTop: 4 }}>{item.trailingSecondary}</Text>
+                              ) : null}
+                            </View>
+                          </TouchableOpacity>
+                        );
+                      }}
                       onEndReached={loadMoreDetail}
                       onEndReachedThreshold={0.6}
                       showsVerticalScrollIndicator={false}
@@ -1161,33 +1236,39 @@ export default function DashboardScreen({ navigation }) {
                 </View>
               ) : detailModal.rows.length ? (
                 <ScrollView showsVerticalScrollIndicator={false}>
-                  {detailModal.rows.map((row, index) => (
-                    <View
-                      key={row.key ?? `${row.title}-${index}`}
-                      style={{
-                        flexDirection: "row",
-                        alignItems: "flex-start",
-                        paddingVertical: 12,
-                        borderTopWidth: index === 0 ? 0 : 1,
-                        borderColor: "#E2E8F0",
-                      }}
-                    >
-                      <View style={{ flex: 1, paddingRight: 12 }}>
-                        <Text style={{ color: "#0F172A", fontWeight: "600" }}>{row.title}</Text>
-                        {row.subtitle ? (
-                          <Text style={{ color: "#64748B", fontSize: 12, marginTop: 4 }}>{row.subtitle}</Text>
-                        ) : null}
-                      </View>
-                      <View style={{ alignItems: "flex-end" }}>
-                        {row.trailingPrimary ? (
-                          <Text style={{ color: "#0F172A", fontWeight: "700" }}>{row.trailingPrimary}</Text>
-                        ) : null}
-                        {row.trailingSecondary ? (
-                          <Text style={{ color: "#94A3B8", fontSize: 12, marginTop: 4 }}>{row.trailingSecondary}</Text>
-                        ) : null}
-                      </View>
-                    </View>
-                  ))}
+                  {detailModal.rows.map((row, index) => {
+                    const isPressable = row?.entityType === "item" || row?.entityType === "po";
+                    return (
+                      <TouchableOpacity
+                        key={row.key ?? `${row.title}-${index}`}
+                        onPress={isPressable ? () => handleDetailRowPress(row) : undefined}
+                        disabled={!isPressable}
+                        activeOpacity={isPressable ? 0.7 : 1}
+                        style={{
+                          flexDirection: "row",
+                          alignItems: "flex-start",
+                          paddingVertical: 12,
+                          borderTopWidth: index === 0 ? 0 : 1,
+                          borderColor: "#E2E8F0",
+                        }}
+                      >
+                        <View style={{ flex: 1, paddingRight: 12 }}>
+                          <Text style={{ color: "#0F172A", fontWeight: "600" }}>{row.title}</Text>
+                          {row.subtitle ? (
+                            <Text style={{ color: "#64748B", fontSize: 12, marginTop: 4 }}>{row.subtitle}</Text>
+                          ) : null}
+                        </View>
+                        <View style={{ alignItems: "flex-end" }}>
+                          {row.trailingPrimary ? (
+                            <Text style={{ color: "#0F172A", fontWeight: "700" }}>{row.trailingPrimary}</Text>
+                          ) : null}
+                          {row.trailingSecondary ? (
+                            <Text style={{ color: "#94A3B8", fontSize: 12, marginTop: 4 }}>{row.trailingSecondary}</Text>
+                          ) : null}
+                        </View>
+                      </TouchableOpacity>
+                    );
+                  })}
                 </ScrollView>
               ) : (
                 <View style={{ paddingVertical: 24 }}>

--- a/src/screens/purchaseOrders/index.js
+++ b/src/screens/purchaseOrders/index.js
@@ -35,11 +35,42 @@ import {
 import { buildOrderItemLabel } from "../../utils/purchaseOrders";
 import { getPOStatusStyle, PO_STATUS_OPTIONS, PO_STATUS_STYLES } from "../../constants";
 
+const ITEM_TABLE_MIN_WIDTH = 640;
+
+const ITEM_TABLE_CONTAINER_STYLE = {
+  borderRadius: 14,
+  borderWidth: 1,
+  borderColor: "#E2E8F0",
+  overflow: "hidden",
+  minWidth: ITEM_TABLE_MIN_WIDTH,
+};
+
+const ITEM_TABLE_HEADER_ROW = {
+  flexDirection: "row",
+  backgroundColor: "#F1F5F9",
+  paddingVertical: 10,
+  paddingHorizontal: 12,
+  minWidth: ITEM_TABLE_MIN_WIDTH,
+};
+
+const ITEM_TABLE_ROW_BASE = {
+  flexDirection: "row",
+  paddingVertical: 12,
+  paddingHorizontal: 12,
+  alignItems: "flex-start",
+  minWidth: ITEM_TABLE_MIN_WIDTH,
+};
+
+const ITEM_TABLE_ROW_DIVIDER = {
+  borderTopWidth: 1,
+  borderColor: "#E2E8F0",
+};
+
 const ITEM_TABLE_COLUMNS = {
-  name: { flexGrow: 1, flexShrink: 1, flexBasis: 0, paddingRight: 12, minWidth: 0 },
-  qty: { flexGrow: 0.9, flexShrink: 1, flexBasis: 88, alignItems: "flex-end", minWidth: 0 },
-  price: { flexGrow: 1.1, flexShrink: 1, flexBasis: 120, alignItems: "flex-end", minWidth: 0 },
-  total: { flexGrow: 1.2, flexShrink: 1, flexBasis: 132, alignItems: "flex-end", minWidth: 0 },
+  name: { flexGrow: 1, flexShrink: 0, flexBasis: 240, paddingRight: 12, minWidth: 220 },
+  qty: { flexGrow: 0, flexShrink: 0, flexBasis: 110, alignItems: "flex-end", minWidth: 110 },
+  price: { flexGrow: 0, flexShrink: 0, flexBasis: 150, alignItems: "flex-end", minWidth: 150 },
+  total: { flexGrow: 0, flexShrink: 0, flexBasis: 160, alignItems: "flex-end", minWidth: 160 },
 };
 
 const ITEM_TABLE_NUMERIC_TEXT = {
@@ -1434,61 +1465,49 @@ export function PurchaseOrderDetailScreen({ route, navigation }) {
         </Text>
         <Text style={{ color: "#0F172A", fontWeight: "700", marginTop: 4 }}>{totalDisplay}</Text>
       </View>
-      <View style={{ borderRadius: 16, borderWidth: 1, borderColor: "#E2E8F0", overflow: "hidden" }}>
-        <View
-          style={{
-            flexDirection: "row",
-            backgroundColor: "#F1F5F9",
-            paddingVertical: 10,
-            paddingHorizontal: 12,
-          }}
-        >
-          <View style={ITEM_TABLE_COLUMNS.name}>
-            <Text style={{ fontWeight: "600", color: "#475569" }}>Deskripsi</Text>
-          </View>
-          <View style={ITEM_TABLE_COLUMNS.qty}>
-            <Text style={{ fontWeight: "600", color: "#475569", textAlign: "right" }}>Qty</Text>
-          </View>
-          <View style={ITEM_TABLE_COLUMNS.price}>
-            <Text style={{ fontWeight: "600", color: "#475569", textAlign: "right" }}>Harga</Text>
-          </View>
-          <View style={ITEM_TABLE_COLUMNS.total}>
-            <Text style={{ fontWeight: "600", color: "#475569", textAlign: "right" }}>Total</Text>
-          </View>
-        </View>
-        {invoiceItems.map((item, index) => {
-          const rowQuantity = formatNumberValue(item.quantity);
-          const rowPrice = formatCurrencyValue(item.price);
-          const rowTotal = formatCurrencyValue((item.quantity || 0) * (item.price || 0));
-          return (
-            <View
-              key={item.id ?? `item-${index}`}
-              style={{
-                flexDirection: "row",
-                paddingVertical: 12,
-                paddingHorizontal: 12,
-                alignItems: "flex-start",
-                borderTopWidth: index === 0 ? 0 : 1,
-                borderColor: "#E2E8F0",
-              }}
-            >
-              <View style={ITEM_TABLE_COLUMNS.name}>
-                <Text style={{ color: "#0F172A" }}>{item.name || "-"}</Text>
-              </View>
-              <View style={[ITEM_TABLE_COLUMNS.qty, ITEM_TABLE_QTY_CONTAINER]}>
-                <Text style={ITEM_TABLE_NUMERIC_TEXT_STRONG}>{rowQuantity}</Text>
-                <Text style={ITEM_TABLE_QTY_UNIT_TEXT}>pcs</Text>
-              </View>
-              <View style={ITEM_TABLE_COLUMNS.price}>
-                <Text style={ITEM_TABLE_NUMERIC_TEXT}>{rowPrice}</Text>
-              </View>
-              <View style={ITEM_TABLE_COLUMNS.total}>
-                <Text style={ITEM_TABLE_NUMERIC_TEXT_STRONG}>{rowTotal}</Text>
-              </View>
+      <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={{ paddingBottom: 0 }}>
+        <View style={ITEM_TABLE_CONTAINER_STYLE}>
+          <View style={ITEM_TABLE_HEADER_ROW}>
+            <View style={ITEM_TABLE_COLUMNS.name}>
+              <Text style={{ fontWeight: "600", color: "#475569" }}>Deskripsi</Text>
             </View>
-          );
-        })}
-      </View>
+            <View style={ITEM_TABLE_COLUMNS.qty}>
+              <Text style={{ fontWeight: "600", color: "#475569", textAlign: "right" }}>Qty</Text>
+            </View>
+            <View style={ITEM_TABLE_COLUMNS.price}>
+              <Text style={{ fontWeight: "600", color: "#475569", textAlign: "right" }}>Harga</Text>
+            </View>
+            <View style={ITEM_TABLE_COLUMNS.total}>
+              <Text style={{ fontWeight: "600", color: "#475569", textAlign: "right" }}>Total</Text>
+            </View>
+          </View>
+          {invoiceItems.map((item, index) => {
+            const rowQuantity = formatNumberValue(item.quantity);
+            const rowPrice = formatCurrencyValue(item.price);
+            const rowTotal = formatCurrencyValue((item.quantity || 0) * (item.price || 0));
+            return (
+              <View
+                key={item.id ?? `item-${index}`}
+                style={[ITEM_TABLE_ROW_BASE, index === 0 ? null : ITEM_TABLE_ROW_DIVIDER]}
+              >
+                <View style={ITEM_TABLE_COLUMNS.name}>
+                  <Text style={{ color: "#0F172A", flexShrink: 0 }}>{item.name || "-"}</Text>
+                </View>
+                <View style={[ITEM_TABLE_COLUMNS.qty, ITEM_TABLE_QTY_CONTAINER]}>
+                  <Text style={ITEM_TABLE_NUMERIC_TEXT_STRONG}>{rowQuantity}</Text>
+                  <Text style={ITEM_TABLE_QTY_UNIT_TEXT}>pcs</Text>
+                </View>
+                <View style={ITEM_TABLE_COLUMNS.price}>
+                  <Text style={ITEM_TABLE_NUMERIC_TEXT}>{rowPrice}</Text>
+                </View>
+                <View style={ITEM_TABLE_COLUMNS.total}>
+                  <Text style={ITEM_TABLE_NUMERIC_TEXT_STRONG}>{rowTotal}</Text>
+                </View>
+              </View>
+            );
+          })}
+        </View>
+      </ScrollView>
       {order.note ? (
         <View style={{ marginTop: 16 }}>
           <Text style={{ color: "#0F172A", fontWeight: "600", marginBottom: 6 }}>Catatan</Text>
@@ -1523,61 +1542,49 @@ export function PurchaseOrderDetailScreen({ route, navigation }) {
           </View>
           <View style={{ marginTop: 20 }}>
             <Text style={{ color: "#0F172A", fontWeight: "600", marginBottom: 10 }}>Daftar Barang</Text>
-            <View style={{ borderRadius: 14, borderWidth: 1, borderColor: "#E2E8F0", overflow: "hidden" }}>
-              <View
-                style={{
-                  flexDirection: "row",
-                  backgroundColor: "#F1F5F9",
-                  paddingVertical: 10,
-                  paddingHorizontal: 12,
-                }}
-              >
-                <View style={ITEM_TABLE_COLUMNS.name}>
-                  <Text style={{ fontWeight: "600", color: "#475569" }}>Barang</Text>
-                </View>
-                <View style={ITEM_TABLE_COLUMNS.qty}>
-                  <Text style={{ fontWeight: "600", color: "#475569", textAlign: "right" }}>Qty</Text>
-                </View>
-                <View style={ITEM_TABLE_COLUMNS.price}>
-                  <Text style={{ fontWeight: "600", color: "#475569", textAlign: "right" }}>Harga</Text>
-                </View>
-                <View style={ITEM_TABLE_COLUMNS.total}>
-                  <Text style={{ fontWeight: "600", color: "#475569", textAlign: "right" }}>Total</Text>
-                </View>
-              </View>
-              {invoiceItems.map((item, index) => {
-                const rowQuantity = formatNumberValue(item.quantity);
-                const rowPrice = formatCurrencyValue(item.price);
-                const rowTotal = formatCurrencyValue((item.quantity || 0) * (item.price || 0));
-                return (
-                  <View
-                    key={item.id ?? `summary-item-${index}`}
-                    style={{
-                      flexDirection: "row",
-                      paddingVertical: 12,
-                      paddingHorizontal: 12,
-                      alignItems: "flex-start",
-                      borderTopWidth: index === 0 ? 0 : 1,
-                      borderColor: "#E2E8F0",
-                    }}
-                  >
-                    <View style={ITEM_TABLE_COLUMNS.name}>
-                      <Text style={{ color: "#0F172A" }}>{item.name || "-"}</Text>
-                    </View>
-                    <View style={[ITEM_TABLE_COLUMNS.qty, ITEM_TABLE_QTY_CONTAINER]}>
-                      <Text style={ITEM_TABLE_NUMERIC_TEXT_STRONG}>{rowQuantity}</Text>
-                      <Text style={ITEM_TABLE_QTY_UNIT_TEXT}>pcs</Text>
-                    </View>
-                    <View style={ITEM_TABLE_COLUMNS.price}>
-                      <Text style={ITEM_TABLE_NUMERIC_TEXT}>{rowPrice}</Text>
-                    </View>
-                    <View style={ITEM_TABLE_COLUMNS.total}>
-                      <Text style={ITEM_TABLE_NUMERIC_TEXT_STRONG}>{rowTotal}</Text>
-                    </View>
+            <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={{ paddingBottom: 0 }}>
+              <View style={ITEM_TABLE_CONTAINER_STYLE}>
+                <View style={ITEM_TABLE_HEADER_ROW}>
+                  <View style={ITEM_TABLE_COLUMNS.name}>
+                    <Text style={{ fontWeight: "600", color: "#475569" }}>Barang</Text>
                   </View>
-                );
-              })}
-            </View>
+                  <View style={ITEM_TABLE_COLUMNS.qty}>
+                    <Text style={{ fontWeight: "600", color: "#475569", textAlign: "right" }}>Qty</Text>
+                  </View>
+                  <View style={ITEM_TABLE_COLUMNS.price}>
+                    <Text style={{ fontWeight: "600", color: "#475569", textAlign: "right" }}>Harga</Text>
+                  </View>
+                  <View style={ITEM_TABLE_COLUMNS.total}>
+                    <Text style={{ fontWeight: "600", color: "#475569", textAlign: "right" }}>Total</Text>
+                  </View>
+                </View>
+                {invoiceItems.map((item, index) => {
+                  const rowQuantity = formatNumberValue(item.quantity);
+                  const rowPrice = formatCurrencyValue(item.price);
+                  const rowTotal = formatCurrencyValue((item.quantity || 0) * (item.price || 0));
+                  return (
+                    <View
+                      key={item.id ?? `summary-item-${index}`}
+                      style={[ITEM_TABLE_ROW_BASE, index === 0 ? null : ITEM_TABLE_ROW_DIVIDER]}
+                    >
+                      <View style={ITEM_TABLE_COLUMNS.name}>
+                        <Text style={{ color: "#0F172A", flexShrink: 0 }}>{item.name || "-"}</Text>
+                      </View>
+                      <View style={[ITEM_TABLE_COLUMNS.qty, ITEM_TABLE_QTY_CONTAINER]}>
+                        <Text style={ITEM_TABLE_NUMERIC_TEXT_STRONG}>{rowQuantity}</Text>
+                        <Text style={ITEM_TABLE_QTY_UNIT_TEXT}>pcs</Text>
+                      </View>
+                      <View style={ITEM_TABLE_COLUMNS.price}>
+                        <Text style={ITEM_TABLE_NUMERIC_TEXT}>{rowPrice}</Text>
+                      </View>
+                      <View style={ITEM_TABLE_COLUMNS.total}>
+                        <Text style={ITEM_TABLE_NUMERIC_TEXT_STRONG}>{rowTotal}</Text>
+                      </View>
+                    </View>
+                  );
+                })}
+              </View>
+            </ScrollView>
           </View>
         </View>
 


### PR DESCRIPTION
## Summary
- keep purchase order item tables horizontal by enforcing column widths and wrapping them in a horizontal scroll container
- add metadata and handlers so dashboard detail lists can open the related item editor or PO detail when tapped

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d36e7d8d8883258cf0614e452386a7