### PR TITLE
Add bookkeeping feature with PDF reports

### DIFF
--- a/src/navigation/RootNavigator.js
+++ b/src/navigation/RootNavigator.js
@@ -8,6 +8,7 @@ import {
   EditPurchaseOrderScreen,
   PurchaseOrderDetailScreen,
 } from "../screens/purchaseOrders";
+import { AddBookkeepingScreen, BookkeepingDetailScreen } from "../screens/bookkeeping";
 
 const Stack = createNativeStackNavigator();
 
@@ -21,6 +22,16 @@ export default function RootNavigator() {
       <Stack.Screen name="AddPurchaseOrder" component={AddPurchaseOrderScreen} options={{ title: "Tambah PO" }} />
       <Stack.Screen name="EditPurchaseOrder" component={EditPurchaseOrderScreen} options={{ title: "Edit PO" }} />
       <Stack.Screen name="PurchaseOrderDetail" component={PurchaseOrderDetailScreen} options={{ title: "Detail PO" }} />
+      <Stack.Screen
+        name="BookkeepingDetail"
+        component={BookkeepingDetailScreen}
+        options={{ title: "Detail Pembukuan" }}
+      />
+      <Stack.Screen
+        name="AddBookkeeping"
+        component={AddBookkeepingScreen}
+        options={{ title: "Tambah Pembukuan" }}
+      />
     </Stack.Navigator>
   );
 }

--- a/src/navigation/TabsNavigator.js
+++ b/src/navigation/TabsNavigator.js
@@ -6,6 +6,7 @@ import DashboardScreen from "../screens/DashboardScreen";
 import { ItemsScreen } from "../screens/Items";
 import { PurchaseOrdersScreen } from "../screens/purchaseOrders";
 import HistoryScreen from "../screens/HistoryScreen";
+import { BookkeepingScreen } from "../screens/bookkeeping";
 
 const Tab = createBottomTabNavigator();
 
@@ -24,6 +25,7 @@ export default function TabsNavigator() {
           if (route.name === "Dashboard") iconName = "grid-outline";
           else if (route.name === "Barang") iconName = "cube-outline";
           else if (route.name === "PO") iconName = "cart-outline";
+          else if (route.name === "Pembukuan") iconName = "book-outline";
           else if (route.name === "History") iconName = "time-outline";
           return <Ionicons name={iconName} size={size ?? 22} color={color} />;
         },
@@ -32,6 +34,7 @@ export default function TabsNavigator() {
       <Tab.Screen name="Dashboard" component={DashboardScreen} />
       <Tab.Screen name="Barang" component={ItemsScreen} />
       <Tab.Screen name="PO" component={PurchaseOrdersScreen} />
+      <Tab.Screen name="Pembukuan" component={BookkeepingScreen} />
       <Tab.Screen name="History" component={HistoryScreen} />
     </Tab.Navigator>
   );

--- a/src/screens/DashboardScreen.js
+++ b/src/screens/DashboardScreen.js
@@ -20,7 +20,12 @@ import { Ionicons, MaterialCommunityIcons } from "@expo/vector-icons";
 
 import StatCard from "../components/StatCard";
 import { CATEGORY_COLORS, getPOStatusStyle } from "../constants";
-import { formatCurrencyValue, formatDateDisplay, formatNumberValue } from "../utils/format";
+import {
+  formatCurrencyValue,
+  formatDateDisplay,
+  formatDateTimeDisplay,
+  formatNumberValue,
+} from "../utils/format";
 import { exec } from "../services/database";
 import { KEYBOARD_AVOIDING_BEHAVIOR } from "../components/FormScrollContainer";
 import { buildOrderItemLabel } from "../utils/purchaseOrders";
@@ -40,10 +45,17 @@ export default function DashboardScreen({ navigation }) {
     poCount: 0,
     poProgress: 0,
     poTotalValue: 0,
+    bookkeepingCount: 0,
+    bookkeepingTotal: 0,
+    itemProfitTotal: 0,
+    poProfitTotal: 0,
   });
   const [categoryStats, setCategoryStats] = useState([]);
   const [topItems, setTopItems] = useState([]);
   const [recentPOs, setRecentPOs] = useState([]);
+  const [recentBookkeeping, setRecentBookkeeping] = useState([]);
+  const [itemProfitLeaders, setItemProfitLeaders] = useState([]);
+  const [poProfitLeaders, setPoProfitLeaders] = useState([]);
   const [refreshing, setRefreshing] = useState(false);
   const [detailModal, setDetailModal] = useState({ visible: false, title: "", description: "", rows: [], type: null });
   const [detailLoading, setDetailLoading] = useState(false);
@@ -275,6 +287,159 @@ export default function DashboardScreen({ navigation }) {
         };
       },
     },
+    bookkeepingFull: {
+      title: "Semua Pembukuan",
+      description: "Daftar lengkap catatan pembukuan.",
+      buildQuery: (search, limit, offset) => ({
+        sql: `
+          SELECT id, name, amount, entry_date, note
+          FROM bookkeeping_entries
+          WHERE (? = '' OR LOWER(name) LIKE ? OR LOWER(IFNULL(note,'')) LIKE ?)
+          ORDER BY entry_date DESC, id DESC
+          LIMIT ? OFFSET ?
+        `,
+        params: [search, `%${search}%`, `%${search}%`, limit + 1, offset],
+      }),
+      mapRow: row => {
+        const entryId = Number(row.id);
+        const noteText = row.note && String(row.note).trim() ? String(row.note) : "";
+        const dateDisplay = formatDateDisplay(row.entry_date);
+        const subtitle = noteText ? `${dateDisplay} • ${noteText}` : dateDisplay;
+        return {
+          key: String(row.id),
+          title: row.name,
+          subtitle,
+          trailingPrimary: formatCurrencyValue(row.amount),
+          entityType: Number.isFinite(entryId) ? "bookkeeping" : undefined,
+          entityId: Number.isFinite(entryId) ? entryId : null,
+        };
+      },
+    },
+    itemProfit: {
+      title: "Profit Barang",
+      description: "Daftar barang dengan profit tertinggi dari stok keluar.",
+      buildQuery: (search, limit, offset) => ({
+        sql: `
+          SELECT
+            i.id as item_id,
+            i.name,
+            i.category,
+            IFNULL(SUM(h.qty), 0) as total_qty,
+            IFNULL(SUM(h.qty * IFNULL(h.unit_price, i.price)), 0) as total_sales,
+            IFNULL(SUM(h.qty * IFNULL(h.unit_cost, i.cost_price)), 0) as total_cost,
+            IFNULL(SUM(h.profit_amount), 0) as total_profit,
+            MAX(h.created_at) as last_activity
+          FROM stock_history h
+          JOIN items i ON i.id = h.item_id
+          WHERE h.type = 'OUT'
+            AND (
+              ? = ''
+              OR LOWER(IFNULL(i.name,'')) LIKE ?
+              OR LOWER(IFNULL(i.category,'')) LIKE ?
+              OR LOWER(IFNULL(h.note,'')) LIKE ?
+            )
+          GROUP BY h.item_id
+          ORDER BY total_profit DESC, last_activity DESC
+          LIMIT ? OFFSET ?
+        `,
+        params: [
+          search,
+          `%${search}%`,
+          `%${search}%`,
+          `%${search}%`,
+          limit + 1,
+          offset,
+        ],
+      }),
+      mapRow: row => {
+        const itemId = Number(row.item_id);
+        const totalProfit = Number(row.total_profit ?? 0);
+        const profitLabel = `${totalProfit >= 0 ? '+' : '-'} ${formatCurrencyValue(Math.abs(totalProfit))}`;
+        const qtyLabel = formatNumberValue(row.total_qty ?? 0);
+        const salesLabel = formatCurrencyValue(row.total_sales ?? 0);
+        const costLabel = formatCurrencyValue(row.total_cost ?? 0);
+        const lastActivityLabel = row.last_activity ? formatDateTimeDisplay(row.last_activity) : 'Belum ada aktivitas';
+        return {
+          key: itemId ? String(itemId) : row.name,
+          title: row.name,
+          subtitle: `${row.category && row.category.trim() ? row.category : 'Tanpa kategori'} • ${qtyLabel} pcs • ${lastActivityLabel}`,
+          trailingPrimary: profitLabel,
+          trailingSecondary: `${salesLabel} • Modal ${costLabel}`,
+          entityType: Number.isFinite(itemId) ? 'item' : undefined,
+          entityId: Number.isFinite(itemId) ? itemId : null,
+        };
+      },
+    },
+    poProfit: {
+      title: "Profit Purchase Order",
+      description: "Purchase order selesai dengan profit tertinggi.",
+      buildQuery: (search, limit, offset) => ({
+        sql: `
+          SELECT
+            po.id,
+            po.orderer_name,
+            po.supplier_name,
+            po.completed_at,
+            po.order_date,
+            IFNULL(SUM(items.quantity), 0) as total_qty,
+            IFNULL(SUM(items.quantity * items.price), 0) as total_sales,
+            IFNULL(SUM(items.quantity * items.cost_price), 0) as total_cost,
+            IFNULL(SUM(items.quantity * (items.price - items.cost_price)), 0) as total_profit,
+            COUNT(items.id) as item_count,
+            COALESCE(
+              (SELECT name FROM purchase_order_items first_items WHERE first_items.order_id = po.id ORDER BY first_items.id LIMIT 1),
+              ''
+            ) as primary_item_name
+          FROM purchase_orders po
+          JOIN purchase_order_items items ON items.order_id = po.id
+          WHERE po.status = 'DONE'
+            AND (
+              ? = ''
+              OR LOWER(IFNULL(po.orderer_name,'')) LIKE ?
+              OR LOWER(IFNULL(po.supplier_name,'')) LIKE ?
+              OR LOWER(IFNULL(po.note,'')) LIKE ?
+              OR EXISTS (
+                SELECT 1 FROM purchase_order_items search_items
+                WHERE search_items.order_id = po.id AND LOWER(search_items.name) LIKE ?
+              )
+            )
+          GROUP BY po.id
+          ORDER BY total_profit DESC, po.completed_at DESC, po.id DESC
+          LIMIT ? OFFSET ?
+        `,
+        params: [
+          search,
+          `%${search}%`,
+          `%${search}%`,
+          `%${search}%`,
+          `%${search}%`,
+          limit + 1,
+          offset,
+        ],
+      }),
+      mapRow: row => {
+        const orderId = Number(row.id);
+        const totalProfit = Number(row.total_profit ?? 0);
+        const profitLabel = `${totalProfit >= 0 ? '+' : '-'} ${formatCurrencyValue(Math.abs(totalProfit))}`;
+        const totalSales = Number(row.total_sales ?? 0);
+        const totalCost = Number(row.total_cost ?? 0);
+        const salesLabel = formatCurrencyValue(totalSales);
+        const costLabel = formatCurrencyValue(totalCost);
+        const qtyLabel = formatNumberValue(row.total_qty ?? 0);
+        const itemCount = Number(row.item_count ?? 0);
+        const itemLabel = buildOrderItemLabel(row.primary_item_name || '', itemCount || (row.primary_item_name ? 1 : 0));
+        const completedLabel = row.completed_at ? formatDateTimeDisplay(row.completed_at) : formatDateDisplay(row.order_date);
+        return {
+          key: orderId ? String(orderId) : itemLabel,
+          title: itemLabel,
+          subtitle: `${row.orderer_name || 'Tanpa pemesan'}${row.supplier_name ? ` • ${row.supplier_name}` : ''} • ${completedLabel}`,
+          trailingPrimary: profitLabel,
+          trailingSecondary: `${salesLabel} • Modal ${costLabel} • ${qtyLabel} pcs`,
+          entityType: Number.isFinite(orderId) ? 'po' : undefined,
+          entityId: Number.isFinite(orderId) ? orderId : null,
+        };
+      },
+    },
   };
 
   const isPaginatedType = type => Boolean(type && PAGINATED_CONFIG[type]);
@@ -358,10 +523,74 @@ export default function DashboardScreen({ navigation }) {
         ORDER BY po.order_date DESC, po.id DESC
         LIMIT 5
       `);
+      const bookkeepingSummaryRes = await exec(`
+        SELECT
+          COUNT(*) as totalEntries,
+          IFNULL(SUM(amount), 0) as totalAmount
+        FROM bookkeeping_entries
+      `);
+      const recentBookkeepingRes = await exec(`
+        SELECT id, name, amount, entry_date, note
+        FROM bookkeeping_entries
+        ORDER BY entry_date DESC, id DESC
+        LIMIT 5
+      `);
+      const itemProfitSummaryRes = await exec(`
+        SELECT IFNULL(SUM(profit_amount), 0) as total_profit
+        FROM stock_history
+        WHERE type = 'OUT'
+      `);
+      const itemProfitLeadersRes = await exec(`
+        SELECT
+          h.item_id,
+          i.name,
+          i.category,
+          IFNULL(SUM(h.profit_amount), 0) as total_profit,
+          IFNULL(SUM(h.qty), 0) as total_qty,
+          MAX(h.created_at) as last_activity
+        FROM stock_history h
+        JOIN items i ON i.id = h.item_id
+        WHERE h.type = 'OUT'
+        GROUP BY h.item_id
+        ORDER BY total_profit DESC, i.name ASC
+        LIMIT 10
+      `);
+      const poProfitSummaryRes = await exec(`
+        SELECT IFNULL(SUM(items.quantity * (items.price - items.cost_price)), 0) as total_profit
+        FROM purchase_orders po
+        JOIN purchase_order_items items ON items.order_id = po.id
+        WHERE po.status = 'DONE'
+      `);
+      const poProfitLeadersRes = await exec(`
+        SELECT
+          po.id,
+          po.orderer_name,
+          po.supplier_name,
+          po.order_date,
+          po.completed_at,
+          IFNULL(SUM(items.quantity), 0) as total_qty,
+          IFNULL(SUM(items.quantity * items.price), 0) as total_value,
+          IFNULL(SUM(items.quantity * items.cost_price), 0) as total_cost,
+          IFNULL(SUM(items.quantity * (items.price - items.cost_price)), 0) as total_profit,
+          COUNT(items.id) as item_count,
+          COALESCE(
+            (SELECT name FROM purchase_order_items first_items WHERE first_items.order_id = po.id ORDER BY first_items.id LIMIT 1),
+            ''
+          ) as primary_item_name
+        FROM purchase_orders po
+        JOIN purchase_order_items items ON items.order_id = po.id
+        WHERE po.status = 'DONE'
+        GROUP BY po.id
+        ORDER BY total_profit DESC, po.completed_at DESC, po.id DESC
+        LIMIT 10
+      `);
 
       const summaryRow = summaryRes.rows.length ? summaryRes.rows.item(0) : {};
       const outRow = outRes.rows.length ? outRes.rows.item(0) : {};
       const poSummaryRow = poSummaryRes.rows.length ? poSummaryRes.rows.item(0) : {};
+      const bookkeepingSummaryRow = bookkeepingSummaryRes.rows.length
+        ? bookkeepingSummaryRes.rows.item(0)
+        : {};
 
       const nextCategoryStats = [];
       for (let i = 0; i < categoryRes.rows.length; i++) {
@@ -410,9 +639,59 @@ export default function DashboardScreen({ navigation }) {
         });
       }
 
+      const nextRecentBookkeeping = [];
+      for (let i = 0; i < recentBookkeepingRes.rows.length; i++) {
+        const row = recentBookkeepingRes.rows.item(i);
+        nextRecentBookkeeping.push({
+          id: row.id,
+          name: row.name,
+          amount: Number(row.amount ?? 0),
+          entryDate: row.entry_date,
+          note: row.note,
+        });
+      }
+
+      const itemProfitTotalRow = itemProfitSummaryRes.rows.length ? itemProfitSummaryRes.rows.item(0) : {};
+      const itemProfitTotal = Number(itemProfitTotalRow.total_profit ?? 0);
+      const nextItemProfitLeaders = [];
+      for (let i = 0; i < itemProfitLeadersRes.rows.length; i++) {
+        const row = itemProfitLeadersRes.rows.item(i);
+        nextItemProfitLeaders.push({
+          itemId: Number(row.item_id),
+          name: row.name,
+          category: row.category,
+          totalProfit: Number(row.total_profit ?? 0),
+          totalQty: Number(row.total_qty ?? 0),
+          lastActivity: row.last_activity,
+        });
+      }
+
+      const poProfitTotalRow = poProfitSummaryRes.rows.length ? poProfitSummaryRes.rows.item(0) : {};
+      const poProfitTotal = Number(poProfitTotalRow.total_profit ?? 0);
+      const nextPoProfitLeaders = [];
+      for (let i = 0; i < poProfitLeadersRes.rows.length; i++) {
+        const row = poProfitLeadersRes.rows.item(i);
+        nextPoProfitLeaders.push({
+          id: row.id,
+          ordererName: row.orderer_name,
+          supplierName: row.supplier_name,
+          orderDate: row.order_date,
+          completedAt: row.completed_at,
+          totalQuantity: Number(row.total_qty ?? 0),
+          totalValue: Number(row.total_value ?? 0),
+          totalCost: Number(row.total_cost ?? 0),
+          totalProfit: Number(row.total_profit ?? 0),
+          itemCount: Number(row.item_count ?? 0),
+          primaryItemName: row.primary_item_name,
+        });
+      }
+
       setCategoryStats(nextCategoryStats);
       setTopItems(nextTopItems);
       setRecentPOs(nextRecentPOs);
+      setRecentBookkeeping(nextRecentBookkeeping);
+      setItemProfitLeaders(nextItemProfitLeaders);
+      setPoProfitLeaders(nextPoProfitLeaders);
       setMetrics({
         totalStock: Number(summaryRow.totalStock ?? 0),
         totalItems: Number(summaryRow.totalItems ?? 0),
@@ -424,6 +703,10 @@ export default function DashboardScreen({ navigation }) {
         poCount: Number(poSummaryRow.totalOrders ?? 0),
         poProgress: Number(poSummaryRow.progressOrders ?? 0),
         poTotalValue: Number(poSummaryRow.totalValue ?? 0),
+        bookkeepingCount: Number(bookkeepingSummaryRow.totalEntries ?? 0),
+        bookkeepingTotal: Number(bookkeepingSummaryRow.totalAmount ?? 0),
+        itemProfitTotal,
+        poProfitTotal,
       });
     } catch (error) {
       console.log("DASHBOARD LOAD ERROR:", error);
@@ -573,6 +856,14 @@ export default function DashboardScreen({ navigation }) {
         orderId,
         onDone: load,
       });
+    } else if (row.entityType === "bookkeeping") {
+      const entryId = Number(row.entityId);
+      if (!Number.isFinite(entryId)) return;
+      closeDetail();
+      navigation.navigate("BookkeepingDetail", {
+        entryId,
+        onDone: load,
+      });
     }
   }
 
@@ -585,6 +876,10 @@ export default function DashboardScreen({ navigation }) {
       poProgress: "poProgress",
       poPending: "poProgress",
       poValue: "poValue",
+      bookkeepingCount: "bookkeepingFull",
+      bookkeepingTotal: "bookkeepingFull",
+      itemProfitTotal: "itemProfit",
+      poProfitTotal: "poProfit",
     };
     const paginatedType = paginatedMap[statKey];
     if (paginatedType) {
@@ -755,6 +1050,150 @@ export default function DashboardScreen({ navigation }) {
     }
   }
 
+  async function openItemProfitDetail(item) {
+    const itemId = Number(item?.itemId ?? item?.id ?? item?.entityId);
+    if (!Number.isFinite(itemId)) return;
+    const totalProfit = Number(item?.totalProfit ?? 0);
+    const totalQty = Number(item?.totalQty ?? 0);
+    setDetailHasMore(false);
+    setDetailSearch("");
+    setDetailSearchInput("");
+    detailPaging.current = { type: "itemProfitHistory", offset: 0, search: "" };
+    setDetailModal({
+      visible: true,
+      title: item?.name ? `Profit ${item.name}` : "Profit Barang",
+      description: `Total profit: ${
+        totalProfit >= 0
+          ? formatCurrencyValue(totalProfit)
+          : `- ${formatCurrencyValue(Math.abs(totalProfit))}`
+      } • Qty keluar: ${formatNumberValue(totalQty)} pcs`,
+      rows: [],
+      type: "itemProfitHistory",
+    });
+    setDetailLoading(true);
+    try {
+      const res = await exec(
+        `
+          SELECT id, qty, note, created_at, unit_price, unit_cost, profit_amount
+          FROM stock_history
+          WHERE item_id = ? AND type = 'OUT'
+          ORDER BY created_at DESC, id DESC
+          LIMIT 50
+        `,
+        [itemId],
+      );
+      const rows = [];
+      for (let i = 0; i < res.rows.length; i++) {
+        const row = res.rows.item(i);
+        const qty = Number(row.qty ?? 0);
+        const price = Number(row.unit_price ?? 0);
+        const cost = Number(row.unit_cost ?? 0);
+        const profit = Number(row.profit_amount ?? 0);
+        const salesTotal = qty * price;
+        const subtitleParts = [
+          `Qty: ${formatNumberValue(qty)} pcs`,
+          `Jual: ${formatCurrencyValue(price)}`,
+          `Modal: ${formatCurrencyValue(cost)}`,
+        ];
+        const noteText = row.note && String(row.note).trim() ? String(row.note) : "";
+        const displaySubtitle = noteText
+          ? `${subtitleParts.join(" • ")}\nCatatan: ${noteText}`
+          : subtitleParts.join(" • ");
+        const profitLabel = `${profit >= 0 ? "+" : "-"} ${formatCurrencyValue(Math.abs(profit))}`;
+        rows.push({
+          key: `history-${row.id}`,
+          title: formatDateTimeDisplay(row.created_at),
+          subtitle: displaySubtitle,
+          trailingPrimary: profitLabel,
+          trailingSecondary: `Omzet ${formatCurrencyValue(salesTotal)}`,
+        });
+      }
+      setDetailModal(prev => ({ ...prev, rows }));
+    } catch (error) {
+      console.log("ITEM PROFIT DETAIL ERROR:", error);
+      setDetailModal({
+        visible: true,
+        title: "Tidak dapat memuat detail",
+        description: "Terjadi kesalahan saat memuat riwayat profit barang.",
+        rows: [],
+        type: "itemProfitHistory",
+      });
+    } finally {
+      setDetailLoading(false);
+    }
+  }
+
+  async function openPoProfitDetail(po) {
+    const orderId = Number(po?.id ?? po?.entityId);
+    if (!Number.isFinite(orderId)) return;
+    const totalProfit = Number(po?.totalProfit ?? 0);
+    const totalSales = Number(po?.totalValue ?? po?.totalSales ?? 0);
+    const totalCost = Number(po?.totalCost ?? 0);
+    const completedLabel = po?.completedAt
+      ? formatDateTimeDisplay(po.completedAt)
+      : po?.orderDate
+      ? formatDateDisplay(po.orderDate)
+      : "-";
+    setDetailHasMore(false);
+    setDetailSearch("");
+    setDetailSearchInput("");
+    detailPaging.current = { type: "poProfitBreakdown", offset: 0, search: "" };
+    setDetailModal({
+      visible: true,
+      title: po?.primaryItemName ? `Profit PO • ${po.primaryItemName}` : "Profit Purchase Order",
+      description: `${
+        totalProfit >= 0
+          ? `Total profit: ${formatCurrencyValue(totalProfit)}`
+          : `Total rugi: - ${formatCurrencyValue(Math.abs(totalProfit))}`
+      } • Omzet: ${formatCurrencyValue(totalSales)} • Modal: ${formatCurrencyValue(totalCost)} • Selesai: ${completedLabel}`,
+      rows: [],
+      type: "poProfitBreakdown",
+    });
+    setDetailLoading(true);
+    try {
+      const res = await exec(
+        `
+          SELECT id, name, quantity, price, cost_price
+          FROM purchase_order_items
+          WHERE order_id = ?
+          ORDER BY id
+        `,
+        [orderId],
+      );
+      const rows = [];
+      for (let i = 0; i < res.rows.length; i++) {
+        const row = res.rows.item(i);
+        const qty = Number(row.quantity ?? 0);
+        const price = Number(row.price ?? 0);
+        const cost = Number(row.cost_price ?? 0);
+        const revenue = qty * price;
+        const totalCostLine = qty * cost;
+        const profit = revenue - totalCostLine;
+        const profitLabel = `${profit >= 0 ? "+" : "-"} ${formatCurrencyValue(Math.abs(profit))}`;
+        const subtitle = `Qty: ${formatNumberValue(qty)} pcs • Harga jual: ${formatCurrencyValue(price)} • Harga modal: ${formatCurrencyValue(cost)}`;
+        rows.push({
+          key: `po-item-${row.id}`,
+          title: row.name,
+          subtitle,
+          trailingPrimary: profitLabel,
+          trailingSecondary: `Omzet ${formatCurrencyValue(revenue)}`,
+        });
+      }
+      setDetailModal(prev => ({ ...prev, rows }));
+    } catch (error) {
+      console.log("PO PROFIT DETAIL ERROR:", error);
+      setDetailModal({
+        visible: true,
+        title: "Tidak dapat memuat detail",
+        description: "Terjadi kesalahan saat memuat rincian profit purchase order.",
+        rows: [],
+        type: "poProfitBreakdown",
+      });
+    } finally {
+      setDetailLoading(false);
+    }
+  }
+
   const stats = [
     {
       key: "categories",
@@ -811,6 +1250,24 @@ export default function DashboardScreen({ navigation }) {
       backgroundColor: "#E0F2FE",
     },
     {
+      key: "bookkeepingCount",
+      label: "Catatan Pembukuan",
+      value: formatNumber(metrics.bookkeepingCount),
+      helper: "Total catatan",
+      icon: "receipt-outline",
+      iconColor: "#7C3AED",
+      backgroundColor: "#F3E8FF",
+    },
+    {
+      key: "bookkeepingTotal",
+      label: "Total Pembukuan",
+      value: formatCurrency(metrics.bookkeepingTotal),
+      helper: "Akumulasi nominal",
+      icon: "wallet-outline",
+      iconColor: "#4338CA",
+      backgroundColor: "#E0E7FF",
+    },
+    {
       key: "poCount",
       label: "Total PO",
       value: formatNumber(metrics.poCount),
@@ -837,11 +1294,38 @@ export default function DashboardScreen({ navigation }) {
       iconColor: "#A855F7",
       backgroundColor: "#F5E8FF",
     },
+    {
+      key: "itemProfitTotal",
+      label: "Profit Barang",
+      value:
+        metrics.itemProfitTotal >= 0
+          ? formatCurrency(metrics.itemProfitTotal)
+          : `- ${formatCurrency(Math.abs(metrics.itemProfitTotal))}`,
+      helper: "Dari stok keluar",
+      icon: "trending-up-outline",
+      iconColor: "#16A34A",
+      backgroundColor: "#DCFCE7",
+    },
+    {
+      key: "poProfitTotal",
+      label: "Profit PO",
+      value:
+        metrics.poProfitTotal >= 0
+          ? formatCurrency(metrics.poProfitTotal)
+          : `- ${formatCurrency(Math.abs(metrics.poProfitTotal))}`,
+      helper: "PO selesai",
+      icon: "pricetag-outline",
+      iconColor: "#F97316",
+      backgroundColor: "#FFEDD5",
+    },
   ];
 
   const displayCategories = categoryStats.slice(0, 5);
   const displayTopItems = topItems.slice(0, 5);
   const displayRecentPOs = recentPOs.slice(0, 5);
+  const displayRecentBookkeeping = recentBookkeeping.slice(0, 5);
+  const displayItemProfit = itemProfitLeaders.slice(0, 5);
+  const displayPoProfit = poProfitLeaders.slice(0, 5);
 
   return (
     <SafeAreaView style={{ flex: 1, backgroundColor: "#F1F5F9", marginBottom: -tabBarHeight }}>
@@ -1047,6 +1531,255 @@ export default function DashboardScreen({ navigation }) {
           >
             <View style={{ flexDirection: "row", justifyContent: "space-between", alignItems: "flex-start", marginBottom: 16 }}>
               <View>
+                <Text style={{ fontSize: 18, fontWeight: "700", color: "#0F172A" }}>Pembukuan Terbaru</Text>
+                <Text style={{ color: "#64748B" }}>
+                  {recentBookkeeping.length ? `${recentBookkeeping.length} catatan` : "Belum ada catatan"}
+                </Text>
+              </View>
+              {recentBookkeeping.length ? (
+                <TouchableOpacity onPress={() => openPaginatedDetail("bookkeepingFull")}>
+                  <Text style={{ color: "#2563EB", fontWeight: "600" }}>Lihat semua</Text>
+                </TouchableOpacity>
+              ) : null}
+            </View>
+            {recentBookkeeping.length ? (
+              displayRecentBookkeeping.map((entry, index) => {
+                const noteText = entry.note && String(entry.note).trim() ? String(entry.note) : "";
+                const subtitle = noteText
+                  ? `${formatDateDisplay(entry.entryDate)} • ${noteText}`
+                  : formatDateDisplay(entry.entryDate);
+                return (
+                  <TouchableOpacity
+                    key={entry.id}
+                    activeOpacity={0.85}
+                    onPress={() =>
+                      navigation.navigate("BookkeepingDetail", {
+                        entryId: entry.id,
+                        initialEntry: entry,
+                        onDone: load,
+                      })
+                    }
+                    style={{
+                      flexDirection: "row",
+                      alignItems: "center",
+                      paddingVertical: 12,
+                      borderTopWidth: index === 0 ? 0 : 1,
+                      borderColor: "#E2E8F0",
+                    }}
+                  >
+                    <View
+                      style={{
+                        width: 44,
+                        height: 44,
+                        borderRadius: 14,
+                        backgroundColor: "#E0E7FF",
+                        alignItems: "center",
+                        justifyContent: "center",
+                        marginRight: 14,
+                      }}
+                    >
+                      <Ionicons name="wallet-outline" size={22} color="#4338CA" />
+                    </View>
+                    <View style={{ flex: 1 }}>
+                      <Text style={{ fontWeight: "700", color: "#0F172A" }}>{entry.name}</Text>
+                      <Text style={{ color: "#64748B", fontSize: 12 }}>{subtitle}</Text>
+                    </View>
+                    <Text style={{ color: "#0F172A", fontWeight: "700" }}>{formatCurrency(entry.amount)}</Text>
+                  </TouchableOpacity>
+                );
+              })
+            ) : (
+              <View style={{ paddingVertical: 16 }}>
+                <Text style={{ color: "#94A3B8" }}>Belum ada catatan pembukuan.</Text>
+              </View>
+            )}
+          </View>
+
+          <View
+            style={{
+              backgroundColor: "#fff",
+              borderRadius: 16,
+              padding: 20,
+              borderWidth: 1,
+              borderColor: "#E2E8F0",
+              shadowColor: "#0F172A",
+              shadowOpacity: 0.05,
+              shadowRadius: 12,
+              elevation: 2,
+            }}
+          >
+            <View style={{ flexDirection: "row", justifyContent: "space-between", alignItems: "flex-start", marginBottom: 16 }}>
+              <View>
+                <Text style={{ fontSize: 18, fontWeight: "700", color: "#0F172A" }}>Profit Barang</Text>
+                <Text style={{ color: "#64748B" }}>
+                  {itemProfitLeaders.length ? `${itemProfitLeaders.length} barang` : "Belum ada data"}
+                </Text>
+              </View>
+              {itemProfitLeaders.length ? (
+                <TouchableOpacity onPress={() => openPaginatedDetail("itemProfit")}>
+                  <Text style={{ color: "#2563EB", fontWeight: "600" }}>Lihat semua</Text>
+                </TouchableOpacity>
+              ) : null}
+            </View>
+            {displayItemProfit.length ? (
+              displayItemProfit.map((entry, index) => {
+                const profit = Number(entry.totalProfit ?? 0);
+                const profitLabel = `${profit >= 0 ? "+" : "-"} ${formatCurrency(Math.abs(profit))}`;
+                const profitColor = profit >= 0 ? "#16A34A" : "#DC2626";
+                const qtyLabel = formatNumber(entry.totalQty ?? 0);
+                const lastLabel = entry.lastActivity
+                  ? formatDateTimeDisplay(entry.lastActivity)
+                  : "Belum ada transaksi";
+                const categoryLabel = entry.category && entry.category.trim() ? entry.category : "Tanpa kategori";
+                return (
+                  <TouchableOpacity
+                    key={`item-profit-${entry.itemId ?? index}`}
+                    onPress={() => openItemProfitDetail(entry)}
+                    activeOpacity={0.85}
+                    style={{
+                      flexDirection: "row",
+                      alignItems: "flex-start",
+                      paddingVertical: 12,
+                      borderTopWidth: index === 0 ? 0 : 1,
+                      borderColor: "#E2E8F0",
+                    }}
+                  >
+                    <View
+                      style={{
+                        width: 44,
+                        height: 44,
+                        borderRadius: 14,
+                        backgroundColor: "#DCFCE7",
+                        alignItems: "center",
+                        justifyContent: "center",
+                        marginRight: 14,
+                      }}
+                    >
+                      <Ionicons name="trending-up-outline" size={22} color="#16A34A" />
+                    </View>
+                    <View style={{ flex: 1, paddingRight: 12 }}>
+                      <Text style={{ fontWeight: "700", color: "#0F172A" }}>{entry.name}</Text>
+                      <Text style={{ color: "#64748B", fontSize: 12 }}>{`${categoryLabel} • ${qtyLabel} pcs`}</Text>
+                      <Text style={{ color: "#94A3B8", fontSize: 12, marginTop: 4 }}>{`Terakhir: ${lastLabel}`}</Text>
+                    </View>
+                    <View style={{ alignItems: "flex-end" }}>
+                      <Text style={{ color: profitColor, fontWeight: "700" }}>{profitLabel}</Text>
+                    </View>
+                  </TouchableOpacity>
+                );
+              })
+            ) : (
+              <View style={{ paddingVertical: 16 }}>
+                <Text style={{ color: "#94A3B8" }}>Belum ada data profit barang. Catat transaksi keluar untuk melihat hasil.</Text>
+              </View>
+            )}
+          </View>
+
+          <View
+            style={{
+              backgroundColor: "#fff",
+              borderRadius: 16,
+              padding: 20,
+              borderWidth: 1,
+              borderColor: "#E2E8F0",
+              shadowColor: "#0F172A",
+              shadowOpacity: 0.05,
+              shadowRadius: 12,
+              elevation: 2,
+            }}
+          >
+            <View style={{ flexDirection: "row", justifyContent: "space-between", alignItems: "flex-start", marginBottom: 16 }}>
+              <View>
+                <Text style={{ fontSize: 18, fontWeight: "700", color: "#0F172A" }}>Profit Purchase Order</Text>
+                <Text style={{ color: "#64748B" }}>
+                  {poProfitLeaders.length ? `${poProfitLeaders.length} PO selesai` : "Belum ada data"}
+                </Text>
+              </View>
+              {poProfitLeaders.length ? (
+                <TouchableOpacity onPress={() => openPaginatedDetail("poProfit")}>
+                  <Text style={{ color: "#2563EB", fontWeight: "600" }}>Lihat semua</Text>
+                </TouchableOpacity>
+              ) : null}
+            </View>
+            {displayPoProfit.length ? (
+              displayPoProfit.map((entry, index) => {
+                const profit = Number(entry.totalProfit ?? 0);
+                const profitLabel = `${profit >= 0 ? "+" : "-"} ${formatCurrency(Math.abs(profit))}`;
+                const profitColor = profit >= 0 ? "#16A34A" : "#DC2626";
+                const revenueLabel = formatCurrency(entry.totalValue ?? 0);
+                const qtyLabel = formatNumber(entry.totalQuantity ?? 0);
+                const partyLabel = entry.supplierName && entry.supplierName.trim()
+                  ? `${entry.ordererName || "Tanpa pemesan"} • ${entry.supplierName}`
+                  : entry.ordererName || "Tanpa pemesan";
+                const completedLabel = entry.completedAt
+                  ? formatDateTimeDisplay(entry.completedAt)
+                  : formatDateDisplay(entry.orderDate);
+                const itemLabel = buildOrderItemLabel(
+                  entry.primaryItemName || "",
+                  entry.itemCount || (entry.primaryItemName ? 1 : 0),
+                );
+                return (
+                  <TouchableOpacity
+                    key={`po-profit-${entry.id ?? index}`}
+                    onPress={() => openPoProfitDetail(entry)}
+                    activeOpacity={0.85}
+                    style={{
+                      flexDirection: "row",
+                      alignItems: "flex-start",
+                      paddingVertical: 12,
+                      borderTopWidth: index === 0 ? 0 : 1,
+                      borderColor: "#E2E8F0",
+                    }}
+                  >
+                    <View
+                      style={{
+                        width: 44,
+                        height: 44,
+                        borderRadius: 14,
+                        backgroundColor: "#FFE4E6",
+                        alignItems: "center",
+                        justifyContent: "center",
+                        marginRight: 14,
+                      }}
+                    >
+                      <MaterialCommunityIcons name="chart-line" size={22} color="#F97316" />
+                    </View>
+                    <View style={{ flex: 1, paddingRight: 12 }}>
+                      <Text style={{ fontWeight: "700", color: "#0F172A" }}>{itemLabel}</Text>
+                      <Text style={{ color: "#64748B", fontSize: 12 }}>{partyLabel}</Text>
+                      <Text style={{ color: "#94A3B8", fontSize: 12, marginTop: 4 }}>{`Selesai: ${completedLabel}`}</Text>
+                    </View>
+                    <View style={{ alignItems: "flex-end" }}>
+                      <Text style={{ color: profitColor, fontWeight: "700" }}>{profitLabel}</Text>
+                      <Text style={{ color: "#94A3B8", fontSize: 12 }}>{`${revenueLabel} • ${qtyLabel} pcs`}</Text>
+                    </View>
+                  </TouchableOpacity>
+                );
+              })
+            ) : (
+              <View style={{ paddingVertical: 16 }}>
+                <Text style={{ color: "#94A3B8" }}>
+                  Belum ada PO selesai dengan data profit. Tandai PO selesai untuk melihat ringkasan.
+                </Text>
+              </View>
+            )}
+          </View>
+
+          <View
+            style={{
+              backgroundColor: "#fff",
+              borderRadius: 16,
+              padding: 20,
+              borderWidth: 1,
+              borderColor: "#E2E8F0",
+              shadowColor: "#0F172A",
+              shadowOpacity: 0.05,
+              shadowRadius: 12,
+              elevation: 2,
+            }}
+          >
+            <View style={{ flexDirection: "row", justifyContent: "space-between", alignItems: "flex-start", marginBottom: 16 }}>
+              <View>
                 <Text style={{ fontSize: 18, fontWeight: "700", color: "#0F172A" }}>PO Terbaru</Text>
                 <Text style={{ color: "#64748B" }}>{recentPOs.length ? `${recentPOs.length} data` : "Belum ada PO"}</Text>
               </View>
@@ -1177,7 +1910,10 @@ export default function DashboardScreen({ navigation }) {
                       data={detailModal.rows}
                       keyExtractor={(item, index) => (item.key ? String(item.key) : `${detailModal.type || "row"}-${index}`)}
                       renderItem={({ item, index }) => {
-                        const isPressable = item?.entityType === "item" || item?.entityType === "po";
+                        const isPressable =
+                          item?.entityType === "item" ||
+                          item?.entityType === "po" ||
+                          item?.entityType === "bookkeeping";
                         return (
                           <TouchableOpacity
                             onPress={isPressable ? () => handleDetailRowPress(item) : undefined}
@@ -1236,7 +1972,10 @@ export default function DashboardScreen({ navigation }) {
               ) : detailModal.rows.length ? (
                 <ScrollView showsVerticalScrollIndicator={false}>
                   {detailModal.rows.map((row, index) => {
-                    const isPressable = row?.entityType === "item" || row?.entityType === "po";
+                    const isPressable =
+                      row?.entityType === "item" ||
+                      row?.entityType === "po" ||
+                      row?.entityType === "bookkeeping";
                     return (
                       <TouchableOpacity
                         key={row.key ?? `${row.title}-${index}`}

--- a/src/screens/bookkeeping/index.js
+++ b/src/screens/bookkeeping/index.js
@@ -1,0 +1,1431 @@
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import {
+  View,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  FlatList,
+  ActivityIndicator,
+  Alert,
+  Modal,
+  Pressable,
+  ScrollView,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { Ionicons } from "@expo/vector-icons";
+import * as Print from "expo-print";
+import * as Sharing from "expo-sharing";
+
+import ActionButton from "../../components/ActionButton";
+import DatePickerField from "../../components/DatePickerField";
+import DetailRow from "../../components/DetailRow";
+import FormScrollContainer from "../../components/FormScrollContainer";
+import Input from "../../components/Input";
+import { exec } from "../../services/database";
+import { saveFileToStorage, resolveShareableUri } from "../../services/files";
+import {
+  buildBookkeepingReportFileBase,
+  formatCurrencyValue,
+  formatDateDisplay,
+  formatDateTimeDisplay,
+  formatDateInputValue,
+  formatNumberInput,
+  formatNumberValue,
+  parseNumberInput,
+} from "../../utils/format";
+
+function buildDefaultReportRange() {
+  const now = new Date();
+  const start = new Date(now.getFullYear(), now.getMonth(), 1);
+  return {
+    startDate: formatDateInputValue(start),
+    endDate: formatDateInputValue(now),
+  };
+}
+
+function escapeHtml(value) {
+  if (value == null) return "";
+  const map = {
+    "&": "&amp;",
+    "<": "&lt;",
+    ">": "&gt;",
+    '"': "&quot;",
+    "'": "&#39;",
+  };
+  return String(value).replace(/[&<>"']/g, char => map[char] || char);
+}
+
+export function BookkeepingScreen({ navigation }) {
+  const PAGE_SIZE = 20;
+  const [entries, setEntries] = useState([]);
+  const [summary, setSummary] = useState({ totalEntries: 0, totalAmount: 0 });
+  const [searchTerm, setSearchTerm] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [hasMore, setHasMore] = useState(false);
+  const [reportModalState, setReportModalState] = useState(() => ({
+    visible: false,
+    ...buildDefaultReportRange(),
+  }));
+  const [reportGenerating, setReportGenerating] = useState(false);
+  const [adjustModal, setAdjustModal] = useState({
+    visible: false,
+    mode: "ADD",
+    entry: null,
+    amount: "",
+    note: "",
+    loading: false,
+  });
+  const pagingRef = useRef({ offset: 0, search: "" });
+  const requestIdRef = useRef(0);
+  const searchInitRef = useRef(false);
+
+  useEffect(() => {
+    loadEntries({ search: searchTerm, reset: true });
+    loadSummary();
+  }, []);
+
+  useEffect(() => {
+    if (!searchInitRef.current) {
+      searchInitRef.current = true;
+      return;
+    }
+    const handler = setTimeout(() => {
+      loadEntries({ search: searchTerm, reset: true });
+    }, 250);
+    return () => clearTimeout(handler);
+  }, [searchTerm]);
+
+  useEffect(() => {
+    const unsubscribe = navigation.addListener("focus", () => {
+      loadEntries({ search: searchTerm, reset: true });
+      loadSummary();
+    });
+    return unsubscribe;
+  }, [navigation, searchTerm]);
+
+  async function loadEntries({ search = searchTerm, reset = false, mode = "default" } = {}) {
+    const normalizedSearch = (search || "").trim().toLowerCase();
+    const isSearchChanged = normalizedSearch !== pagingRef.current.search;
+    const shouldReset = reset || isSearchChanged;
+    const offset = shouldReset ? 0 : pagingRef.current.offset;
+    const limit = PAGE_SIZE + 1;
+    const requestId = ++requestIdRef.current;
+
+    if (mode === "refresh") setRefreshing(true);
+    else if (mode === "loadMore") setLoadingMore(true);
+    else setLoading(true);
+
+    try {
+      const res = await exec(
+        `
+          SELECT id, name, amount, entry_date, note
+          FROM bookkeeping_entries
+          WHERE (? = '' OR LOWER(name) LIKE ? OR LOWER(IFNULL(note,'')) LIKE ?)
+          ORDER BY entry_date DESC, id DESC
+          LIMIT ? OFFSET ?
+        `,
+        [normalizedSearch, `%${normalizedSearch}%`, `%${normalizedSearch}%`, limit, offset],
+      );
+      if (requestId !== requestIdRef.current) return;
+      const rowsArray = res.rows?._array ?? [];
+      const pageEntries = rowsArray.slice(0, PAGE_SIZE).map(row => ({
+        id: row.id,
+        name: row.name,
+        amount: Number(row.amount ?? 0),
+        entryDate: row.entry_date,
+        note: row.note,
+      }));
+      const nextOffset = offset + pageEntries.length;
+      setHasMore(rowsArray.length > PAGE_SIZE);
+      setEntries(prev => (shouldReset ? pageEntries : [...prev, ...pageEntries]));
+      pagingRef.current = { offset: nextOffset, search: normalizedSearch };
+    } catch (error) {
+      console.log("BOOKKEEPING LOAD ERROR:", error);
+      if (mode === "default") {
+        Alert.alert("Gagal", "Tidak dapat memuat data pembukuan.");
+      }
+    } finally {
+      if (requestId === requestIdRef.current) {
+        if (mode === "refresh") setRefreshing(false);
+        else if (mode === "loadMore") setLoadingMore(false);
+        else setLoading(false);
+      }
+    }
+  }
+
+  async function loadSummary() {
+    try {
+      const res = await exec(`
+        SELECT
+          COUNT(*) as totalEntries,
+          IFNULL(SUM(amount), 0) as totalAmount
+        FROM bookkeeping_entries
+      `);
+      const row = res.rows.length ? res.rows.item(0) : {};
+      setSummary({
+        totalEntries: Number(row.totalEntries ?? 0),
+        totalAmount: Number(row.totalAmount ?? 0),
+      });
+    } catch (error) {
+      console.log("BOOKKEEPING SUMMARY ERROR:", error);
+    }
+  }
+
+  const handleRefresh = () => {
+    loadSummary();
+    loadEntries({ search: searchTerm, reset: true, mode: "refresh" });
+  };
+
+  const handleLoadMore = () => {
+    if (!loadingMore && hasMore) {
+      loadEntries({ search: searchTerm, reset: false, mode: "loadMore" });
+    }
+  };
+
+  const openReportModal = () => {
+    const defaults = buildDefaultReportRange();
+    setReportModalState({ visible: true, ...defaults });
+  };
+
+  const closeReportModal = () => {
+    if (reportGenerating) return;
+    setReportModalState(prev => ({ ...prev, visible: false }));
+  };
+
+  const openAdjustModal = (entry, mode = "ADD") => {
+    if (!entry) return;
+    setAdjustModal({
+      visible: true,
+      mode,
+      entry,
+      amount: "",
+      note: "",
+      loading: false,
+    });
+  };
+
+  const closeAdjustModal = () => {
+    setAdjustModal({ visible: false, mode: "ADD", entry: null, amount: "", note: "", loading: false });
+  };
+
+  const handleAdjustAmountChange = text => {
+    setAdjustModal(prev => ({ ...prev, amount: formatNumberInput(text) }));
+  };
+
+  const handleAdjustNoteChange = text => {
+    setAdjustModal(prev => ({ ...prev, note: text }));
+  };
+
+  const handleAdjustSubmit = useCallback(async () => {
+    const { entry, mode, amount, note, loading: submitting } = adjustModal;
+    if (!entry || submitting) return;
+    const parsedAmount = parseNumberInput(amount);
+    if (parsedAmount <= 0) {
+      Alert.alert("Validasi", "Nominal harus lebih dari 0.");
+      return;
+    }
+    const delta = mode === "ADD" ? parsedAmount : -parsedAmount;
+    setAdjustModal(prev => ({ ...prev, loading: true }));
+    try {
+      await exec("BEGIN TRANSACTION");
+      const currentRes = await exec(`SELECT amount FROM bookkeeping_entries WHERE id = ?`, [entry.id]);
+      const currentRow = currentRes.rows.length ? currentRes.rows.item(0) : { amount: entry.amount ?? 0 };
+      const currentAmount = Number(currentRow.amount ?? 0);
+      const nextAmount = currentAmount + delta;
+      await exec(`UPDATE bookkeeping_entries SET amount = ? WHERE id = ?`, [nextAmount, entry.id]);
+      await exec(
+        `INSERT INTO bookkeeping_entry_history (entry_id, change_amount, type, note, previous_amount, new_amount)` +
+          ` VALUES (?,?,?,?,?,?)`,
+        [
+          entry.id,
+          delta,
+          mode,
+          note && note.trim() ? note.trim() : null,
+          currentAmount,
+          nextAmount,
+        ],
+      );
+      await exec("COMMIT");
+      closeAdjustModal();
+      loadSummary();
+      loadEntries({ search: searchTerm, reset: true });
+    } catch (error) {
+      console.log("BOOKKEEPING ADJUST ERROR:", error);
+      try {
+        await exec("ROLLBACK");
+      } catch (rollbackError) {
+        console.log("BOOKKEEPING ADJUST ROLLBACK ERROR:", rollbackError);
+      }
+      setAdjustModal(prev => ({ ...prev, loading: false }));
+      Alert.alert("Gagal", "Perubahan nominal tidak dapat disimpan.");
+    }
+  }, [adjustModal, loadEntries, loadSummary, searchTerm]);
+
+  const handleGenerateReport = useCallback(async () => {
+    const { startDate, endDate } = reportModalState;
+    if (!startDate || !endDate) {
+      Alert.alert("Validasi", "Tanggal mulai dan akhir wajib dipilih.");
+      return;
+    }
+    if (startDate > endDate) {
+      Alert.alert("Validasi", "Tanggal mulai tidak boleh melebihi tanggal akhir.");
+      return;
+    }
+    setReportGenerating(true);
+    try {
+      const res = await exec(
+        `
+          SELECT id, name, amount, entry_date, note, created_at
+          FROM bookkeeping_entries
+          WHERE entry_date BETWEEN ? AND ?
+          ORDER BY entry_date ASC, id ASC
+        `,
+        [startDate, endDate],
+      );
+      const rows = [];
+      for (let i = 0; i < res.rows.length; i++) {
+        const row = res.rows.item(i);
+        rows.push({
+          id: row.id,
+          name: row.name,
+          amount: Number(row.amount ?? 0),
+          entryDate: row.entry_date,
+          note: row.note,
+          createdAt: row.created_at,
+        });
+      }
+      if (!rows.length) {
+        Alert.alert("Tidak Ada Data", "Tidak ada catatan pembukuan dalam rentang tanggal tersebut.");
+        return;
+      }
+      const totalAmount = rows.reduce((sum, entry) => sum + Number(entry.amount ?? 0), 0);
+      const startDisplay = formatDateDisplay(startDate);
+      const endDisplay = formatDateDisplay(endDate);
+      const rowsHtml = rows
+        .map((entry, index) => {
+          const noteText = entry.note ? escapeHtml(entry.note) : "-";
+          return `
+            <tr>
+              <td class="col-index">${index + 1}</td>
+              <td class="col-date">${escapeHtml(formatDateDisplay(entry.entryDate))}</td>
+              <td class="col-name">${escapeHtml(entry.name)}</td>
+              <td class="col-note">${noteText}</td>
+              <td class="col-amount">${escapeHtml(formatCurrencyValue(entry.amount))}</td>
+            </tr>
+          `;
+        })
+        .join("");
+      const fileBase = buildBookkeepingReportFileBase({ startDate, endDate });
+      const html = `
+        <!DOCTYPE html>
+        <html lang="id">
+          <head>
+            <meta charset="utf-8" />
+            <title>Laporan Pembukuan</title>
+            <style>
+              * { box-sizing: border-box; font-family: 'Inter', 'Helvetica', 'Arial', sans-serif; }
+              body { background: #f1f5f9; color: #0f172a; margin: 0; padding: 24px; }
+              .card { max-width: 900px; margin: 0 auto; background: #fff; border-radius: 24px; padding: 32px; box-shadow: 0 18px 40px rgba(15, 23, 42, 0.12); }
+              .header { display: flex; justify-content: space-between; align-items: flex-start; gap: 16px; margin-bottom: 24px; }
+              .header h1 { margin: 0; font-size: 28px; }
+              .range { color: #64748b; margin-top: 4px; font-size: 14px; }
+              .summary { display: flex; gap: 24px; flex-wrap: wrap; margin-bottom: 24px; }
+              .summary-item { background: #f8fafc; border-radius: 16px; padding: 16px 20px; flex: 1 1 220px; }
+              .summary-item h2 { margin: 0 0 8px; font-size: 14px; color: #64748b; text-transform: uppercase; letter-spacing: 0.08em; }
+              .summary-item p { margin: 0; font-size: 18px; font-weight: 600; }
+              table { width: 100%; border-collapse: collapse; }
+              thead { background: #f8fafc; }
+              th, td { text-align: left; padding: 12px 14px; border-bottom: 1px solid #e2e8f0; vertical-align: top; }
+              th { font-size: 12px; color: #64748b; text-transform: uppercase; letter-spacing: 0.08em; }
+              td { font-size: 14px; color: #0f172a; }
+              .col-index { width: 48px; text-align: center; }
+              .col-date { width: 140px; }
+              .col-name { width: 220px; }
+              .col-note { width: 100%; }
+              .col-amount { width: 140px; text-align: right; font-variant-numeric: tabular-nums; font-weight: 600; }
+              tfoot td { font-weight: 700; color: #0f172a; }
+            </style>
+          </head>
+          <body>
+            <div class="card">
+              <div class="header">
+                <div>
+                  <p style="letter-spacing: 0.08em; text-transform: uppercase; color: #94a3b8; margin: 0 0 8px;">Laporan</p>
+                  <h1>Pembukuan Gudang</h1>
+                  <p class="range">${escapeHtml(startDisplay)} - ${escapeHtml(endDisplay)}</p>
+                </div>
+              </div>
+              <div class="summary">
+                <div class="summary-item">
+                  <h2>Total Catatan</h2>
+                  <p>${rows.length.toLocaleString("id-ID")}</p>
+                </div>
+                <div class="summary-item">
+                  <h2>Total Nominal</h2>
+                  <p>${escapeHtml(formatCurrencyValue(totalAmount))}</p>
+                </div>
+              </div>
+              <table>
+                <thead>
+                  <tr>
+                    <th class="col-index">No</th>
+                    <th class="col-date">Tanggal</th>
+                    <th class="col-name">Nama</th>
+                    <th class="col-note">Catatan</th>
+                    <th class="col-amount">Nominal</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  ${rowsHtml}
+                </tbody>
+                <tfoot>
+                  <tr>
+                    <td colspan="4" style="text-align: right;">Total</td>
+                    <td class="col-amount">${escapeHtml(formatCurrencyValue(totalAmount))}</td>
+                  </tr>
+                </tfoot>
+              </table>
+            </div>
+          </body>
+        </html>
+      `;
+      const { uri } = await Print.printToFileAsync({ html, base64: false, fileName: fileBase });
+      const { uri: savedUri, location: savedLocation, notice: savedNotice, displayPath: savedDisplayPath } = await saveFileToStorage(
+        uri,
+        `${fileBase}.pdf`,
+        "application/pdf",
+      );
+      if (await Sharing.isAvailableAsync()) {
+        const shareUri = await resolveShareableUri(`${fileBase}-share.pdf`, uri, savedUri);
+        if (shareUri) {
+          await Sharing.shareAsync(shareUri, {
+            mimeType: "application/pdf",
+            dialogTitle: "Bagikan Laporan Pembukuan",
+            UTI: "com.adobe.pdf",
+          });
+        }
+      }
+      const locationMessage = savedDisplayPath
+        ? `File tersimpan di ${savedDisplayPath}.`
+        : savedLocation === "external"
+        ? "File tersimpan di folder yang kamu pilih."
+        : `File tersimpan di ${savedUri}.`;
+      const alertMessage = savedNotice ? `${savedNotice}\n\n${locationMessage}` : locationMessage;
+      Alert.alert("Laporan Dibuat", alertMessage);
+      setReportModalState(prev => ({ ...prev, visible: false }));
+    } catch (error) {
+      console.log("BOOKKEEPING REPORT ERROR:", error);
+      Alert.alert("Gagal", "Laporan tidak dapat dibuat saat ini.");
+    } finally {
+      setReportGenerating(false);
+    }
+  }, [reportModalState]);
+
+  const renderItem = ({ item }) => (
+    <View
+      style={{
+        backgroundColor: "#fff",
+        padding: 14,
+        borderRadius: 12,
+        borderWidth: 1,
+        borderColor: "#E5E7EB",
+        marginBottom: 10,
+      }}
+    >
+      <TouchableOpacity
+        activeOpacity={0.85}
+        onPress={() =>
+          navigation.navigate("BookkeepingDetail", {
+            entryId: item.id,
+            initialEntry: item,
+            onDone: () => {
+              loadEntries({ search: searchTerm, reset: true });
+              loadSummary();
+            },
+          })
+        }
+      >
+        <View style={{ flexDirection: "row", justifyContent: "space-between", alignItems: "flex-start" }}>
+          <View style={{ flex: 1, paddingRight: 12 }}>
+            <Text style={{ fontWeight: "700", color: "#0F172A", marginBottom: 4 }}>{item.name}</Text>
+            <Text style={{ color: "#64748B", fontSize: 12 }}>{formatDateDisplay(item.entryDate)}</Text>
+            {item.note ? (
+              <Text style={{ color: "#475569", marginTop: 6 }} numberOfLines={2}>
+                {item.note}
+              </Text>
+            ) : null}
+          </View>
+          <Text style={{ color: "#2563EB", fontWeight: "700" }}>{formatCurrencyValue(item.amount)}</Text>
+        </View>
+      </TouchableOpacity>
+      <View style={{ flexDirection: "row", gap: 8, marginTop: 12 }}>
+        <TouchableOpacity
+          onPress={() => openAdjustModal(item, "ADD")}
+          style={{
+            flex: 1,
+            paddingVertical: 10,
+            borderRadius: 10,
+            borderWidth: 1,
+            borderColor: "#22C55E",
+            alignItems: "center",
+            backgroundColor: "#F0FDF4",
+          }}
+        >
+          <Text style={{ color: "#15803D", fontWeight: "600" }}>+ Tambah</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          onPress={() => openAdjustModal(item, "SUBTRACT")}
+          style={{
+            flex: 1,
+            paddingVertical: 10,
+            borderRadius: 10,
+            borderWidth: 1,
+            borderColor: "#F87171",
+            alignItems: "center",
+            backgroundColor: "#FEF2F2",
+          }}
+        >
+          <Text style={{ color: "#DC2626", fontWeight: "600" }}>- Kurangi</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+
+  const adjustModeLabel = adjustModal.mode === "ADD" ? "Tambah Nominal" : "Kurangi Nominal";
+  const adjustAmountValue = parseNumberInput(adjustModal.amount);
+  const adjustCurrentAmount = Number(adjustModal.entry?.amount ?? 0);
+  const adjustNextAmount =
+    adjustModal.mode === "SUBTRACT"
+      ? adjustCurrentAmount - adjustAmountValue
+      : adjustCurrentAmount + adjustAmountValue;
+
+  return (
+    <SafeAreaView style={{ flex: 1, backgroundColor: "#F8FAFC" }}>
+      <View style={{ flex: 1, padding: 16 }}>
+        <Text style={{ fontSize: 22, fontWeight: "700", color: "#0F172A", marginBottom: 12 }}>Pembukuan</Text>
+
+        <View style={{ flexDirection: "row", gap: 12, marginBottom: 16 }}>
+          <View
+            style={{
+              flex: 1,
+              backgroundColor: "#fff",
+              borderRadius: 16,
+              borderWidth: 1,
+              borderColor: "#E2E8F0",
+              padding: 16,
+            }}
+          >
+            <Text style={{ color: "#94A3B8", fontSize: 12, textTransform: "uppercase", letterSpacing: 0.08 }}>Catatan</Text>
+            <Text style={{ fontSize: 20, fontWeight: "700", color: "#0F172A", marginTop: 6 }}>
+              {formatNumberValue(summary.totalEntries)}
+            </Text>
+            <Text style={{ color: "#64748B", marginTop: 4 }}>Total catatan tersimpan</Text>
+          </View>
+          <View
+            style={{
+              flex: 1,
+              backgroundColor: "#fff",
+              borderRadius: 16,
+              borderWidth: 1,
+              borderColor: "#E2E8F0",
+              padding: 16,
+            }}
+          >
+            <Text style={{ color: "#94A3B8", fontSize: 12, textTransform: "uppercase", letterSpacing: 0.08 }}>Nominal</Text>
+            <Text style={{ fontSize: 20, fontWeight: "700", color: "#0F172A", marginTop: 6 }}>
+              {formatCurrencyValue(summary.totalAmount)}
+            </Text>
+            <Text style={{ color: "#64748B", marginTop: 4 }}>Akumulasi nominal</Text>
+          </View>
+        </View>
+
+        <TextInput
+          placeholder="Cari nama atau catatan…"
+          value={searchTerm}
+          onChangeText={setSearchTerm}
+          style={{
+            backgroundColor: "#fff",
+            borderWidth: 1,
+            borderColor: "#E5E7EB",
+            borderRadius: 12,
+            paddingHorizontal: 12,
+            height: 44,
+            marginBottom: 12,
+          }}
+          placeholderTextColor="#94A3B8"
+        />
+
+        <View style={{ flexDirection: "row", gap: 10, marginBottom: 16 }}>
+          <TouchableOpacity
+            onPress={openReportModal}
+            style={{
+              flexDirection: "row",
+              alignItems: "center",
+              backgroundColor: "#0EA5E9",
+              paddingHorizontal: 16,
+              borderRadius: 12,
+              height: 44,
+            }}
+          >
+            <Ionicons name="document-text-outline" size={18} color="#fff" style={{ marginRight: 8 }} />
+            <Text style={{ color: "#fff", fontWeight: "700" }}>Laporan PDF</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            onPress={() =>
+              navigation.navigate("AddBookkeeping", {
+                onDone: () => {
+                  loadEntries({ search: searchTerm, reset: true });
+                  loadSummary();
+                },
+              })
+            }
+            style={{
+              flex: 1,
+              backgroundColor: "#2563EB",
+              paddingHorizontal: 16,
+              borderRadius: 12,
+              alignItems: "center",
+              justifyContent: "center",
+              height: 44,
+            }}
+          >
+            <Text style={{ color: "#fff", fontWeight: "700" }}>+ Pembukuan</Text>
+          </TouchableOpacity>
+        </View>
+
+        <FlatList
+          data={entries}
+          keyExtractor={item => String(item.id)}
+          renderItem={renderItem}
+          refreshing={refreshing}
+          onRefresh={handleRefresh}
+          onEndReached={handleLoadMore}
+          onEndReachedThreshold={0.3}
+          ListFooterComponent={
+            loadingMore ? (
+              <View style={{ paddingVertical: 16 }}>
+                <ActivityIndicator color="#2563EB" />
+              </View>
+            ) : null
+          }
+          ListEmptyComponent={
+            loading ? (
+              <View style={{ paddingVertical: 40 }}>
+                <ActivityIndicator color="#2563EB" />
+              </View>
+            ) : (
+              <View style={{ paddingVertical: 40, alignItems: "center" }}>
+                <Ionicons name="document-text-outline" size={32} color="#CBD5F5" />
+                <Text style={{ color: "#94A3B8", marginTop: 8 }}>
+                  {searchTerm.trim() ? "Tidak ada catatan yang cocok." : "Belum ada catatan pembukuan."}
+                </Text>
+              </View>
+            )
+          }
+          contentContainerStyle={{ paddingBottom: 32 }}
+        />
+      </View>
+
+      <Modal
+        visible={adjustModal.visible}
+        transparent
+        animationType="fade"
+        onRequestClose={closeAdjustModal}
+        statusBarTranslucent
+      >
+        <Pressable
+          onPress={closeAdjustModal}
+          style={{ flex: 1, backgroundColor: "rgba(15,23,42,0.45)" }}
+        />
+        <View
+          style={{
+            position: "absolute",
+            left: 0,
+            right: 0,
+            bottom: 0,
+            backgroundColor: "#fff",
+            borderTopLeftRadius: 24,
+            borderTopRightRadius: 24,
+            padding: 20,
+            paddingBottom: 28,
+            shadowColor: "#0F172A",
+            shadowOpacity: 0.1,
+            shadowRadius: 18,
+            elevation: 6,
+          }}
+        >
+          <View style={{ flexDirection: "row", justifyContent: "space-between", alignItems: "center" }}>
+            <View style={{ flex: 1, paddingRight: 12 }}>
+              <Text style={{ fontSize: 18, fontWeight: "700", color: "#0F172A" }}>{adjustModeLabel}</Text>
+              <Text style={{ color: "#64748B", marginTop: 4 }}>{adjustModal.entry?.name || "-"}</Text>
+            </View>
+            <TouchableOpacity onPress={closeAdjustModal} disabled={adjustModal.loading}>
+              <Ionicons name="close" size={22} color="#94A3B8" />
+            </TouchableOpacity>
+          </View>
+          <Text style={{ color: "#0F172A", fontWeight: "600", marginTop: 12 }}>
+            Saldo saat ini: {formatCurrencyValue(adjustCurrentAmount)}
+          </Text>
+          <View style={{ marginTop: 16 }}>
+            <Text style={{ color: "#64748B", marginBottom: 6 }}>Nominal</Text>
+            <TextInput
+              value={adjustModal.amount}
+              onChangeText={handleAdjustAmountChange}
+              placeholder="contoh: 250000"
+              keyboardType="numeric"
+              style={{
+                borderWidth: 1,
+                borderColor: "#E2E8F0",
+                borderRadius: 12,
+                paddingHorizontal: 12,
+                height: 44,
+              }}
+              placeholderTextColor="#94A3B8"
+            />
+          </View>
+          <View style={{ marginTop: 12 }}>
+            <Text style={{ color: "#64748B", marginBottom: 6 }}>Catatan (opsional)</Text>
+            <TextInput
+              value={adjustModal.note}
+              onChangeText={handleAdjustNoteChange}
+              placeholder="contoh: Penyesuaian kas"
+              style={{
+                borderWidth: 1,
+                borderColor: "#E2E8F0",
+                borderRadius: 12,
+                paddingHorizontal: 12,
+                paddingVertical: 10,
+                height: 96,
+                textAlignVertical: "top",
+              }}
+              placeholderTextColor="#94A3B8"
+              multiline
+            />
+          </View>
+          <View style={{ flexDirection: "row", justifyContent: "space-between", marginTop: 16 }}>
+            <Text style={{ color: "#64748B" }}>Saldo setelah update</Text>
+            <Text style={{ color: "#0F172A", fontWeight: "700" }}>{formatCurrencyValue(adjustNextAmount)}</Text>
+          </View>
+          <TouchableOpacity
+            onPress={handleAdjustSubmit}
+            disabled={adjustModal.loading}
+            style={{
+              marginTop: 18,
+              backgroundColor: adjustModal.loading ? "#93C5FD" : "#2563EB",
+              paddingVertical: 14,
+              borderRadius: 12,
+              alignItems: "center",
+            }}
+          >
+            {adjustModal.loading ? (
+              <ActivityIndicator color="#fff" />
+            ) : (
+              <Text style={{ color: "#fff", fontWeight: "700" }}>Simpan Perubahan</Text>
+            )}
+          </TouchableOpacity>
+          <TouchableOpacity
+            onPress={closeAdjustModal}
+            disabled={adjustModal.loading}
+            style={{
+              marginTop: 12,
+              paddingVertical: 12,
+              borderRadius: 12,
+              alignItems: "center",
+              borderWidth: 1,
+              borderColor: "#CBD5F5",
+            }}
+          >
+            <Text style={{ color: "#2563EB", fontWeight: "600" }}>Batal</Text>
+          </TouchableOpacity>
+        </View>
+      </Modal>
+
+      <Modal
+        visible={reportModalState.visible}
+        transparent
+        animationType="fade"
+        onRequestClose={closeReportModal}
+        statusBarTranslucent
+      >
+        <Pressable
+          onPress={closeReportModal}
+          style={{ flex: 1, backgroundColor: "rgba(15,23,42,0.55)" }}
+        />
+        <View
+          style={{
+            position: "absolute",
+            left: 0,
+            right: 0,
+            bottom: 0,
+            backgroundColor: "#fff",
+            borderTopLeftRadius: 24,
+            borderTopRightRadius: 24,
+            padding: 20,
+            paddingBottom: 24,
+            shadowColor: "#0F172A",
+            shadowOpacity: 0.12,
+            shadowRadius: 16,
+            elevation: 6,
+          }}
+        >
+          <View style={{ flexDirection: "row", justifyContent: "space-between", alignItems: "center" }}>
+            <Text style={{ fontSize: 18, fontWeight: "700", color: "#0F172A" }}>Laporan Pembukuan</Text>
+            <TouchableOpacity onPress={closeReportModal} disabled={reportGenerating}>
+              <Ionicons name="close" size={22} color="#94A3B8" />
+            </TouchableOpacity>
+          </View>
+          <Text style={{ color: "#64748B", marginTop: 6 }}>
+            Pilih rentang tanggal untuk membuat laporan pembukuan dalam format PDF.
+          </Text>
+          <View style={{ marginTop: 18 }}>
+            <DatePickerField
+              label="Tanggal Mulai"
+              value={reportModalState.startDate}
+              onChange={value => setReportModalState(prev => ({ ...prev, startDate: value }))}
+            />
+            <DatePickerField
+              label="Tanggal Akhir"
+              value={reportModalState.endDate}
+              onChange={value => setReportModalState(prev => ({ ...prev, endDate: value }))}
+            />
+          </View>
+          <TouchableOpacity
+            onPress={handleGenerateReport}
+            disabled={reportGenerating}
+            style={{
+              marginTop: 12,
+              backgroundColor: reportGenerating ? "#93C5FD" : "#2563EB",
+              paddingVertical: 14,
+              borderRadius: 12,
+              alignItems: "center",
+            }}
+          >
+            {reportGenerating ? (
+              <ActivityIndicator color="#fff" />
+            ) : (
+              <Text style={{ color: "#fff", fontWeight: "700" }}>Generate PDF</Text>
+            )}
+          </TouchableOpacity>
+        </View>
+      </Modal>
+    </SafeAreaView>
+  );
+}
+
+export function AddBookkeepingScreen({ route, navigation }) {
+  const onDone = route.params?.onDone;
+  const initialEntry = route.params?.entry || null;
+  const [entryId, setEntryId] = useState(initialEntry?.id ?? null);
+  const [name, setName] = useState(initialEntry?.name ?? "");
+  const [amount, setAmount] = useState(
+    initialEntry ? formatNumberInput(String(initialEntry.amount ?? "")) : "",
+  );
+  const [entryDate, setEntryDate] = useState(initialEntry?.entryDate || formatDateInputValue(new Date()));
+  const [note, setNote] = useState(initialEntry?.note ?? "");
+
+  useEffect(() => {
+    if (initialEntry) {
+      setEntryId(initialEntry.id);
+      setName(initialEntry.name || "");
+      setAmount(formatNumberInput(String(initialEntry.amount ?? "")));
+      setEntryDate(initialEntry.entryDate || formatDateInputValue(new Date()));
+      setNote(initialEntry.note || "");
+      navigation.setOptions({ title: "Edit Pembukuan" });
+    } else {
+      resetForm();
+    }
+  }, [initialEntry?.id, navigation]);
+
+  function resetForm() {
+    setEntryId(null);
+    setName("");
+    setAmount("");
+    setEntryDate(formatDateInputValue(new Date()));
+    setNote("");
+    navigation.setOptions({ title: "Tambah Pembukuan" });
+  }
+
+  const isEdit = Boolean(entryId);
+
+  async function save() {
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      Alert.alert("Validasi", "Nama pembukuan wajib diisi.");
+      return;
+    }
+    if (!entryDate) {
+      Alert.alert("Validasi", "Tanggal wajib diisi.");
+      return;
+    }
+    const parsedAmount = parseNumberInput(amount);
+    if (parsedAmount <= 0) {
+      Alert.alert("Validasi", "Nominal harus lebih dari 0.");
+      return;
+    }
+    const trimmedNote = note && note.trim() ? note.trim() : null;
+    try {
+      if (isEdit) {
+        const currentRes = await exec(`SELECT amount FROM bookkeeping_entries WHERE id = ?`, [entryId]);
+        const currentAmount = currentRes.rows.length ? Number(currentRes.rows.item(0).amount ?? 0) : 0;
+        await exec(
+          `UPDATE bookkeeping_entries SET name = ?, amount = ?, entry_date = ?, note = ? WHERE id = ?`,
+          [trimmedName, parsedAmount, entryDate, trimmedNote, entryId],
+        );
+        if (currentAmount !== parsedAmount) {
+          const delta = parsedAmount - currentAmount;
+          await exec(
+            `INSERT INTO bookkeeping_entry_history (entry_id, change_amount, type, note, previous_amount, new_amount)` +
+              ` VALUES (?,?,?,?,?,?)`,
+            [entryId, delta, "EDIT", trimmedNote, currentAmount, parsedAmount],
+          );
+        }
+      } else {
+        const insertRes = await exec(
+          `INSERT INTO bookkeeping_entries (name, amount, entry_date, note) VALUES (?,?,?,?)`,
+          [trimmedName, parsedAmount, entryDate, trimmedNote],
+        );
+        const newId = insertRes.insertId;
+        if (newId) {
+          await exec(
+            `INSERT INTO bookkeeping_entry_history (entry_id, change_amount, type, note, previous_amount, new_amount)` +
+              ` VALUES (?,?,?,?,?,?)`,
+            [newId, parsedAmount, "CREATE", trimmedNote, 0, parsedAmount],
+          );
+        }
+      }
+      onDone && onDone();
+      navigation.goBack();
+    } catch (error) {
+      console.log("BOOKKEEPING SAVE ERROR:", error);
+      Alert.alert("Gagal", "Data pembukuan tidak dapat disimpan.");
+    }
+  }
+
+  return (
+    <SafeAreaView style={{ flex: 1, backgroundColor: "#F8FAFC" }}>
+      <FormScrollContainer contentContainerStyle={{ paddingBottom: 24 }}>
+        <Text style={{ fontSize: 20, fontWeight: "700", marginBottom: 12 }}>
+          {isEdit ? "Edit Pembukuan" : "Tambah Pembukuan"}
+        </Text>
+        <Input
+          label="Nama Pembukuan"
+          value={name}
+          onChangeText={setName}
+          placeholder="contoh: Penjualan harian"
+        />
+        <Input
+          label="Nominal (Rp)"
+          value={amount}
+          onChangeText={text => setAmount(formatNumberInput(text))}
+          keyboardType="numeric"
+          placeholder="contoh: 1500000"
+        />
+        <DatePickerField label="Tanggal" value={entryDate} onChange={setEntryDate} />
+        <Input
+          label="Catatan (opsional)"
+          value={note}
+          onChangeText={setNote}
+          placeholder="contoh: Pembayaran tunai"
+          multiline
+          style={{ height: 100, textAlignVertical: "top", paddingTop: 12 }}
+        />
+        <TouchableOpacity
+          onPress={save}
+          style={{
+            marginTop: 16,
+            backgroundColor: "#2563EB",
+            paddingVertical: 14,
+            borderRadius: 12,
+            alignItems: "center",
+          }}
+        >
+          <Text style={{ color: "#fff", fontWeight: "700" }}>
+            {isEdit ? "Simpan Perubahan" : "Simpan"}
+          </Text>
+        </TouchableOpacity>
+        {isEdit ? (
+          <TouchableOpacity
+            onPress={resetForm}
+            style={{
+              marginTop: 12,
+              paddingVertical: 12,
+              borderRadius: 12,
+              alignItems: "center",
+              borderWidth: 1,
+              borderColor: "#CBD5F5",
+            }}
+          >
+            <Text style={{ color: "#2563EB", fontWeight: "600" }}>Buat Catatan Baru</Text>
+          </TouchableOpacity>
+        ) : null}
+      </FormScrollContainer>
+    </SafeAreaView>
+  );
+}
+
+export function BookkeepingDetailScreen({ route, navigation }) {
+  const entryIdParam = route.params?.entryId;
+  const onDone = route.params?.onDone;
+  const initialEntry = route.params?.initialEntry;
+  const normalizeEntry = useCallback(data => {
+    if (!data) return null;
+    return {
+      id: data.id,
+      name: data.name || "",
+      amount: Number(data.amount ?? 0),
+      entryDate: data.entryDate || data.entry_date || formatDateInputValue(new Date()),
+      note: data.note || "",
+      createdAt: data.createdAt || data.created_at || null,
+    };
+  }, []);
+
+  const [entry, setEntry] = useState(() => normalizeEntry(initialEntry));
+  const [history, setHistory] = useState([]);
+  const [loading, setLoading] = useState(() => !initialEntry);
+  const [adjustModal, setAdjustModal] = useState({
+    visible: false,
+    mode: "ADD",
+    amount: "",
+    note: "",
+    loading: false,
+  });
+  const entryId = Number(entryIdParam);
+  const HISTORY_LIMIT = 50;
+
+  const load = useCallback(async () => {
+    if (!Number.isFinite(entryId)) {
+      setEntry(null);
+      setHistory([]);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    try {
+      const res = await exec(
+        `SELECT id, name, amount, entry_date, note, created_at FROM bookkeeping_entries WHERE id = ?`,
+        [entryId],
+      );
+      if (!res.rows.length) {
+        setEntry(null);
+        setHistory([]);
+        return;
+      }
+      const row = res.rows.item(0);
+      const normalized = normalizeEntry({
+        id: row.id,
+        name: row.name,
+        amount: row.amount,
+        entryDate: row.entry_date,
+        note: row.note,
+        createdAt: row.created_at,
+      });
+      setEntry(normalized);
+      const historyRes = await exec(
+        `
+          SELECT id, change_amount, type, note, previous_amount, new_amount, created_at
+          FROM bookkeeping_entry_history
+          WHERE entry_id = ?
+          ORDER BY id DESC
+          LIMIT ?
+        `,
+        [entryId, HISTORY_LIMIT],
+      );
+      const historyRows = [];
+      for (let i = 0; i < historyRes.rows.length; i++) {
+        const historyRow = historyRes.rows.item(i);
+        historyRows.push({
+          id: historyRow.id,
+          changeAmount: Number(historyRow.change_amount ?? 0),
+          type: historyRow.type,
+          note: historyRow.note,
+          previousAmount: Number(historyRow.previous_amount ?? 0),
+          newAmount: Number(historyRow.new_amount ?? 0),
+          createdAt: historyRow.created_at,
+        });
+      }
+      setHistory(historyRows);
+    } catch (error) {
+      console.log("BOOKKEEPING DETAIL LOAD ERROR:", error);
+    } finally {
+      setLoading(false);
+    }
+  }, [entryId, normalizeEntry]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const refreshParent = useCallback(() => {
+    if (typeof onDone === "function") {
+      onDone();
+    }
+  }, [onDone]);
+
+  const openAdjustModal = useCallback(
+    mode => {
+      if (!entry) return;
+      setAdjustModal({ visible: true, mode, amount: "", note: "", loading: false });
+    },
+    [entry],
+  );
+
+  const closeAdjustModal = useCallback(() => {
+    setAdjustModal({ visible: false, mode: "ADD", amount: "", note: "", loading: false });
+  }, []);
+
+  const handleAdjustAmountChange = text => {
+    setAdjustModal(prev => ({ ...prev, amount: formatNumberInput(text) }));
+  };
+
+  const handleAdjustNoteChange = text => {
+    setAdjustModal(prev => ({ ...prev, note: text }));
+  };
+
+  const handleAdjustSubmit = useCallback(async () => {
+    if (!entry) return;
+    const { mode, amount, note, loading: submitting } = adjustModal;
+    if (submitting) return;
+    const parsedAmount = parseNumberInput(amount);
+    if (parsedAmount <= 0) {
+      Alert.alert("Validasi", "Nominal harus lebih dari 0.");
+      return;
+    }
+    const delta = mode === "ADD" ? parsedAmount : -parsedAmount;
+    setAdjustModal(prev => ({ ...prev, loading: true }));
+    try {
+      await exec("BEGIN TRANSACTION");
+      const currentRes = await exec(`SELECT amount FROM bookkeeping_entries WHERE id = ?`, [entry.id]);
+      const currentRow = currentRes.rows.length ? currentRes.rows.item(0) : { amount: entry.amount ?? 0 };
+      const currentAmount = Number(currentRow.amount ?? 0);
+      const nextAmount = currentAmount + delta;
+      await exec(`UPDATE bookkeeping_entries SET amount = ? WHERE id = ?`, [nextAmount, entry.id]);
+      await exec(
+        `INSERT INTO bookkeeping_entry_history (entry_id, change_amount, type, note, previous_amount, new_amount)` +
+          ` VALUES (?,?,?,?,?,?)`,
+        [
+          entry.id,
+          delta,
+          mode,
+          note && note.trim() ? note.trim() : null,
+          currentAmount,
+          nextAmount,
+        ],
+      );
+      await exec("COMMIT");
+      closeAdjustModal();
+      refreshParent();
+      load();
+    } catch (error) {
+      console.log("BOOKKEEPING DETAIL ADJUST ERROR:", error);
+      try {
+        await exec("ROLLBACK");
+      } catch (rollbackError) {
+        console.log("BOOKKEEPING DETAIL ADJUST ROLLBACK ERROR:", rollbackError);
+      }
+      setAdjustModal(prev => ({ ...prev, loading: false }));
+      Alert.alert("Gagal", "Nominal tidak dapat diperbarui.");
+    }
+  }, [adjustModal, entry, closeAdjustModal, load, refreshParent]);
+
+  const handleEdit = useCallback(() => {
+    if (!entry) return;
+    navigation.navigate("AddBookkeeping", {
+      entry,
+      onDone: () => {
+        load();
+        refreshParent();
+      },
+    });
+  }, [entry, navigation, load, refreshParent]);
+
+  const confirmDelete = useCallback(() => {
+    if (!entry) return;
+    Alert.alert(
+      "Hapus Pembukuan",
+      `Yakin ingin menghapus ${entry.name || "catatan ini"}?`,
+      [
+        { text: "Batal", style: "cancel" },
+        {
+          text: "Hapus",
+          style: "destructive",
+          onPress: async () => {
+            try {
+              await exec(`DELETE FROM bookkeeping_entries WHERE id = ?`, [entry.id]);
+              refreshParent();
+              navigation.goBack();
+            } catch (error) {
+              console.log("BOOKKEEPING DELETE ERROR:", error);
+              Alert.alert("Gagal", "Catatan tidak dapat dihapus.");
+            }
+          },
+        },
+      ],
+    );
+  }, [entry, navigation, refreshParent]);
+
+  if (loading && !entry) {
+    return (
+      <SafeAreaView style={{ flex: 1, backgroundColor: "#F8FAFC", alignItems: "center", justifyContent: "center" }}>
+        <ActivityIndicator color="#2563EB" />
+        <Text style={{ marginTop: 12, color: "#64748B" }}>Memuat detail…</Text>
+      </SafeAreaView>
+    );
+  }
+
+  if (!entry) {
+    return (
+      <SafeAreaView
+        style={{
+          flex: 1,
+          backgroundColor: "#F8FAFC",
+          alignItems: "center",
+          justifyContent: "center",
+          padding: 24,
+        }}
+      >
+        <Ionicons name="document-text-outline" size={42} color="#CBD5F5" />
+        <Text style={{ marginTop: 12, color: "#94A3B8", textAlign: "center" }}>Catatan pembukuan tidak ditemukan.</Text>
+        <TouchableOpacity
+          onPress={() => navigation.goBack()}
+          style={{
+            marginTop: 18,
+            paddingHorizontal: 20,
+            paddingVertical: 10,
+            borderRadius: 12,
+            backgroundColor: "#2563EB",
+          }}
+        >
+          <Text style={{ color: "#fff", fontWeight: "700" }}>Kembali</Text>
+        </TouchableOpacity>
+      </SafeAreaView>
+    );
+  }
+
+  const formattedAmount = formatCurrencyValue(entry.amount);
+  const formattedDate = formatDateDisplay(entry.entryDate);
+  const createdDisplay = entry.createdAt ? formatDateDisplay(entry.createdAt) : "-";
+  const noteDisplay = entry.note && entry.note.trim() ? entry.note : "-";
+  const adjustModeLabel = adjustModal.mode === "ADD" ? "Tambah Nominal" : "Kurangi Nominal";
+  const adjustAmountValue = parseNumberInput(adjustModal.amount);
+  const adjustCurrentAmount = Number(entry.amount ?? 0);
+  const adjustNextAmount =
+    adjustModal.mode === "SUBTRACT"
+      ? adjustCurrentAmount - adjustAmountValue
+      : adjustCurrentAmount + adjustAmountValue;
+
+  return (
+    <SafeAreaView style={{ flex: 1, backgroundColor: "#F8FAFC" }}>
+      <ScrollView contentContainerStyle={{ padding: 16, paddingBottom: 32 }}>
+        <View
+          style={{
+            backgroundColor: "#fff",
+            padding: 18,
+            borderRadius: 16,
+            borderWidth: 1,
+            borderColor: "#E2E8F0",
+            marginBottom: 16,
+          }}
+        >
+          <Text style={{ fontSize: 22, fontWeight: "700", color: "#0F172A" }}>{entry.name}</Text>
+          <View style={{ marginTop: 18, gap: 14 }}>
+            <DetailRow label="Tanggal" value={formattedDate} />
+            <DetailRow label="Nominal" value={formattedAmount} bold />
+            <DetailRow label="Catatan" value={noteDisplay} multiline />
+            <DetailRow label="Dibuat" value={createdDisplay} />
+          </View>
+        </View>
+        <View
+          style={{
+            flexDirection: "row",
+            flexWrap: "wrap",
+            gap: 12,
+            rowGap: 12,
+            marginBottom: 20,
+          }}
+        >
+          <ActionButton label="Tambah Nominal" onPress={() => openAdjustModal("ADD")} color="#16A34A" />
+          <ActionButton label="Kurangi Nominal" onPress={() => openAdjustModal("SUBTRACT")} color="#F97316" />
+          <ActionButton label="Edit" onPress={handleEdit} color="#2563EB" />
+          <ActionButton label="Hapus" onPress={confirmDelete} color="#E11D48" />
+        </View>
+        <View
+          style={{
+            backgroundColor: "#fff",
+            padding: 18,
+            borderRadius: 16,
+            borderWidth: 1,
+            borderColor: "#E2E8F0",
+          }}
+        >
+          <View style={{ flexDirection: "row", justifyContent: "space-between", alignItems: "center" }}>
+            <Text style={{ fontSize: 18, fontWeight: "700", color: "#0F172A" }}>Riwayat Perubahan</Text>
+            {history.length ? (
+              <Text style={{ color: "#94A3B8", fontSize: 12 }}>{`Menampilkan ${history.length} catatan`}</Text>
+            ) : null}
+          </View>
+          {history.length ? (
+            <View style={{ marginTop: 12, gap: 12 }}>
+              {history.map(item => {
+                const changeColor = item.changeAmount >= 0 ? "#16A34A" : "#DC2626";
+                const changeLabel = `${item.changeAmount >= 0 ? "+" : "-"} ${formatCurrencyValue(Math.abs(item.changeAmount))}`;
+                const typeLabel =
+                  item.type === "ADD"
+                    ? "Penambahan"
+                    : item.type === "SUBTRACT"
+                    ? "Pengurangan"
+                    : item.type === "CREATE"
+                    ? "Catatan Baru"
+                    : item.type === "EDIT"
+                    ? "Perubahan"
+                    : item.type;
+                return (
+                  <View key={item.id} style={{ borderWidth: 1, borderColor: "#E2E8F0", borderRadius: 12, padding: 12 }}>
+                    <View style={{ flexDirection: "row", justifyContent: "space-between", alignItems: "center" }}>
+                      <Text style={{ color: changeColor, fontWeight: "700" }}>{changeLabel}</Text>
+                      <Text style={{ color: "#94A3B8", fontSize: 12 }}>
+                        {formatDateTimeDisplay(item.createdAt)}
+                      </Text>
+                    </View>
+                    <Text style={{ color: "#0F172A", marginTop: 6, fontWeight: "600" }}>
+                      Saldo: {formatCurrencyValue(item.newAmount)}
+                    </Text>
+                    <Text style={{ color: "#94A3B8", fontSize: 12, marginTop: 2 }}>
+                      Sebelumnya: {formatCurrencyValue(item.previousAmount)}
+                    </Text>
+                    <Text style={{ color: "#94A3B8", fontSize: 12, marginTop: 2 }}>Jenis: {typeLabel}</Text>
+                    {item.note ? (
+                      <Text style={{ color: "#64748B", marginTop: 6 }}>{item.note}</Text>
+                    ) : null}
+                  </View>
+                );
+              })}
+            </View>
+          ) : (
+            <View style={{ alignItems: "center", paddingVertical: 24 }}>
+              <Ionicons name="time-outline" size={28} color="#CBD5F5" />
+              <Text style={{ color: "#94A3B8", marginTop: 8 }}>Belum ada riwayat penyesuaian.</Text>
+            </View>
+          )}
+        </View>
+      </ScrollView>
+
+      <Modal
+        visible={adjustModal.visible}
+        transparent
+        animationType="fade"
+        onRequestClose={closeAdjustModal}
+        statusBarTranslucent
+      >
+        <Pressable
+          onPress={closeAdjustModal}
+          style={{ flex: 1, backgroundColor: "rgba(15,23,42,0.45)" }}
+        />
+        <View
+          style={{
+            position: "absolute",
+            left: 0,
+            right: 0,
+            bottom: 0,
+            backgroundColor: "#fff",
+            borderTopLeftRadius: 24,
+            borderTopRightRadius: 24,
+            padding: 20,
+            paddingBottom: 28,
+            shadowColor: "#0F172A",
+            shadowOpacity: 0.12,
+            shadowRadius: 18,
+            elevation: 6,
+          }}
+        >
+          <View style={{ flexDirection: "row", justifyContent: "space-between", alignItems: "center" }}>
+            <View style={{ flex: 1, paddingRight: 12 }}>
+              <Text style={{ fontSize: 18, fontWeight: "700", color: "#0F172A" }}>{adjustModeLabel}</Text>
+              <Text style={{ color: "#64748B", marginTop: 4 }}>{entry.name}</Text>
+            </View>
+            <TouchableOpacity onPress={closeAdjustModal} disabled={adjustModal.loading}>
+              <Ionicons name="close" size={22} color="#94A3B8" />
+            </TouchableOpacity>
+          </View>
+          <Text style={{ color: "#0F172A", fontWeight: "600", marginTop: 12 }}>
+            Saldo saat ini: {formatCurrencyValue(adjustCurrentAmount)}
+          </Text>
+          <View style={{ marginTop: 16 }}>
+            <Text style={{ color: "#64748B", marginBottom: 6 }}>Nominal</Text>
+            <TextInput
+              value={adjustModal.amount}
+              onChangeText={handleAdjustAmountChange}
+              placeholder="contoh: 250000"
+              keyboardType="numeric"
+              style={{
+                borderWidth: 1,
+                borderColor: "#E2E8F0",
+                borderRadius: 12,
+                paddingHorizontal: 12,
+                height: 44,
+              }}
+              placeholderTextColor="#94A3B8"
+            />
+          </View>
+          <View style={{ marginTop: 12 }}>
+            <Text style={{ color: "#64748B", marginBottom: 6 }}>Catatan (opsional)</Text>
+            <TextInput
+              value={adjustModal.note}
+              onChangeText={handleAdjustNoteChange}
+              placeholder="contoh: Penyesuaian"
+              style={{
+                borderWidth: 1,
+                borderColor: "#E2E8F0",
+                borderRadius: 12,
+                paddingHorizontal: 12,
+                paddingVertical: 10,
+                height: 96,
+                textAlignVertical: "top",
+              }}
+              placeholderTextColor="#94A3B8"
+              multiline
+            />
+          </View>
+          <View style={{ flexDirection: "row", justifyContent: "space-between", marginTop: 16 }}>
+            <Text style={{ color: "#64748B" }}>Saldo setelah update</Text>
+            <Text style={{ color: "#0F172A", fontWeight: "700" }}>{formatCurrencyValue(adjustNextAmount)}</Text>
+          </View>
+          <TouchableOpacity
+            onPress={handleAdjustSubmit}
+            disabled={adjustModal.loading}
+            style={{
+              marginTop: 18,
+              backgroundColor: adjustModal.loading ? "#93C5FD" : "#2563EB",
+              paddingVertical: 14,
+              borderRadius: 12,
+              alignItems: "center",
+            }}
+          >
+            {adjustModal.loading ? (
+              <ActivityIndicator color="#fff" />
+            ) : (
+              <Text style={{ color: "#fff", fontWeight: "700" }}>Simpan Perubahan</Text>
+            )}
+          </TouchableOpacity>
+          <TouchableOpacity
+            onPress={closeAdjustModal}
+            disabled={adjustModal.loading}
+            style={{
+              marginTop: 12,
+              paddingVertical: 12,
+              borderRadius: 12,
+              alignItems: "center",
+              borderWidth: 1,
+              borderColor: "#CBD5F5",
+            }}
+          >
+            <Text style={{ color: "#2563EB", fontWeight: "600" }}>Batal</Text>
+          </TouchableOpacity>
+        </View>
+      </Modal>
+    </SafeAreaView>
+  );
+}
+
+export default BookkeepingScreen;

--- a/src/services/database.js
+++ b/src/services/database.js
@@ -51,14 +51,67 @@ export async function ensureDbReady() {
         "price INTEGER NOT NULL DEFAULT 0," +
         "FOREIGN KEY(order_id) REFERENCES purchase_orders(id) ON DELETE CASCADE" +
         ");";
+      const createBookkeepingSql =
+        "CREATE TABLE IF NOT EXISTS bookkeeping_entries (" +
+        "id INTEGER PRIMARY KEY AUTOINCREMENT," +
+        "name TEXT NOT NULL," +
+        "amount INTEGER NOT NULL DEFAULT 0," +
+        "entry_date TEXT NOT NULL," +
+        "note TEXT," +
+        "created_at TEXT NOT NULL DEFAULT (datetime('now','localtime'))" +
+        ");";
+      const createBookkeepingHistorySql =
+        "CREATE TABLE IF NOT EXISTS bookkeeping_entry_history (" +
+        "id INTEGER PRIMARY KEY AUTOINCREMENT," +
+        "entry_id INTEGER NOT NULL," +
+        "change_amount INTEGER NOT NULL," +
+        "type TEXT NOT NULL," +
+        "note TEXT," +
+        "previous_amount INTEGER," +
+        "new_amount INTEGER," +
+        "created_at TEXT NOT NULL DEFAULT (datetime('now','localtime'))," +
+        "FOREIGN KEY(entry_id) REFERENCES bookkeeping_entries(id) ON DELETE CASCADE" +
+        ");";
       await db.execAsync(createItemsSql);
       await db.execAsync(createHistorySql);
       await db.execAsync(createPurchaseOrderSql);
       await db.execAsync(createPurchaseOrderItemsSql);
+      await db.execAsync(createBookkeepingSql);
+      await db.execAsync(createBookkeepingHistorySql);
       try {
         await db.execAsync("ALTER TABLE purchase_orders ADD COLUMN orderer_name TEXT");
       } catch (error) {
         // ignore if column already exists
+      }
+      try {
+        await db.execAsync("ALTER TABLE items ADD COLUMN cost_price INTEGER NOT NULL DEFAULT 0");
+      } catch (error) {
+        // column already exists
+      }
+      try {
+        await db.execAsync("ALTER TABLE stock_history ADD COLUMN unit_price INTEGER");
+      } catch (error) {
+        // column already exists
+      }
+      try {
+        await db.execAsync("ALTER TABLE stock_history ADD COLUMN unit_cost INTEGER");
+      } catch (error) {
+        // column already exists
+      }
+      try {
+        await db.execAsync("ALTER TABLE stock_history ADD COLUMN profit_amount INTEGER NOT NULL DEFAULT 0");
+      } catch (error) {
+        // column already exists
+      }
+      try {
+        await db.execAsync("ALTER TABLE purchase_order_items ADD COLUMN cost_price INTEGER NOT NULL DEFAULT 0");
+      } catch (error) {
+        // column already exists
+      }
+      try {
+        await db.execAsync("ALTER TABLE purchase_orders ADD COLUMN completed_at TEXT");
+      } catch (error) {
+        // column already exists
       }
       try {
         await db.execAsync("UPDATE purchase_orders SET status = 'PROGRESS' WHERE status = 'PENDING'");

--- a/src/utils/format.js
+++ b/src/utils/format.js
@@ -25,6 +25,21 @@ export function formatDateDisplay(value) {
   return date.toLocaleDateString("id-ID", { day: "numeric", month: "long", year: "numeric" });
 }
 
+export function formatDateTimeDisplay(value) {
+  if (!value) return "-";
+  const safeValue = value.length === 10 ? `${value}T00:00:00` : value;
+  const date = new Date(safeValue);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString("id-ID", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+}
+
 export function parseDateString(value) {
   if (!value) return new Date();
   if (typeof value === "string" && /^\d{4}-\d{2}-\d{2}$/.test(value)) {
@@ -56,4 +71,11 @@ export function buildPOFileBase(order) {
   const itemSlug = safeSlug(order?.primaryItemName || order?.itemName || "barang");
   const dateSlug = safeSlug(formatDateInputValue(new Date()));
   return `${ordererSlug}_${itemSlug}_${dateSlug}`;
+}
+
+export function buildBookkeepingReportFileBase(range = {}) {
+  const todaySlug = safeSlug(formatDateInputValue(new Date()));
+  const startSlug = range.startDate ? safeSlug(range.startDate) : todaySlug;
+  const endSlug = range.endDate ? safeSlug(range.endDate) : startSlug;
+  return `laporan-pembukuan_${startSlug}_sd_${endSlug}`;
 }


### PR DESCRIPTION
## Summary
- add bookkeeping screens to manage bookkeeping entries with CRUD and PDF reporting
- create persistent storage for bookkeeping entries and wire the screens into navigation
- surface bookkeeping metrics and recent entries on the dashboard
- ensure purchase order status updates manage completion timestamps and show completion times in detail views

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d3eb98eeb48325915f1081e2c8cf4b